### PR TITLE
Add rumble support

### DIFF
--- a/libretro/input_plugin.c
+++ b/libretro/input_plugin.c
@@ -268,8 +268,10 @@ EXPORT void CALL inputInitiateControllers(CONTROL_INFO ControlInfo)
       controller[i].control->RawData = 0;
       if (pad_pak_types[i] == PLUGIN_MEMPAK)
          controller[i].control->Plugin = PLUGIN_MEMPAK;
-      else
+      else if (pad_pak_types[i] == PLUGIN_RAW)
          controller[i].control->Plugin = PLUGIN_RAW;
+      else
+         controller[i].control->Plugin = PLUGIN_NONE;
     }
 }
 

--- a/libretro/input_plugin.c
+++ b/libretro/input_plugin.c
@@ -26,8 +26,10 @@
 #include <string.h>
 
 #include "libretro.h"
-extern retro_input_state_t    input_cb;
+
+extern retro_input_state_t input_cb;
 extern struct retro_rumble_interface rumble;
+extern int pad_pak_types[4];
 
 #define M64P_PLUGIN_PROTOTYPES 1
 #include "m64p_types.h"
@@ -45,8 +47,6 @@ extern struct retro_rumble_interface rumble;
 #define RD_WRITEEPROM       0x05        // write eeprom
 
 #define PAK_IO_RUMBLE       0xC000      // the address where rumble-commands are sent to
-
-extern int pad_pak_types[4];
 
 /* global data definitions */
 struct
@@ -159,7 +159,6 @@ EXPORT void CALL inputControllerCommand(int Control, unsigned char *Command)
                         rumble.set_rumble_state(Control, RETRO_RUMBLE_STRONG, 0);
                     }
                 }
-                
             }
             
             break;
@@ -263,15 +262,16 @@ EXPORT void CALL inputInitiateControllers(CONTROL_INFO ControlInfo)
 
     for( i = 0; i < 4; i++ )
     {
-      controller[i].control = ControlInfo.Controls + i;
-      controller[i].control->Present = 1;
-      controller[i].control->RawData = 0;
-      if (pad_pak_types[i] == PLUGIN_MEMPAK)
-         controller[i].control->Plugin = PLUGIN_MEMPAK;
-      else if (pad_pak_types[i] == PLUGIN_RAW)
-         controller[i].control->Plugin = PLUGIN_RAW;
-      else
-         controller[i].control->Plugin = PLUGIN_NONE;
+       controller[i].control = ControlInfo.Controls + i;
+       controller[i].control->Present = 1;
+       controller[i].control->RawData = 0;
+       
+       if (pad_pak_types[i] == PLUGIN_MEMPAK)
+          controller[i].control->Plugin = PLUGIN_MEMPAK;
+       else if (pad_pak_types[i] == PLUGIN_RAW)
+          controller[i].control->Plugin = PLUGIN_RAW;
+       else
+          controller[i].control->Plugin = PLUGIN_NONE;
     }
 }
 

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -44,13 +44,16 @@ static enum gfx_plugin_type gfx_plugin;
 static uint32_t screen_width;
 static uint32_t screen_height;
 
-// argh ugly horrible hacks kill them with fire
+// after the controller's CONTROL* member has been assigned we can update
+// them straight from here...
 extern struct
 {
     CONTROL *control;
     BUTTONS buttons;
 } controller[4];
 
+// ...but it won't be at least the first time we're called, in that case set
+// these instead for input_plugin to read.
 int pad_pak_types[4];
 
 static void n64DebugCallback(void* aContext, int aLevel, const char* aMessage)
@@ -303,13 +306,11 @@ void update_variables(void)
       struct retro_variable pk1var = { "mupen64-pak1" };
       if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &pk1var) && pk1var.value)
       {
-         int p1_pak = 0;
+         int p1_pak = PLUGIN_NONE;
          if (!strcmp(pk1var.value, "rumble"))
             p1_pak = PLUGIN_RAW;
          else if (!strcmp(pk1var.value, "memory"))
             p1_pak = PLUGIN_MEMPAK;
-         else
-            p1_pak = PLUGIN_NONE;
          
          // If controller struct is not initialised yet, set pad_pak_types instead
          // which will be looked at when initialising the controllers.
@@ -325,13 +326,11 @@ void update_variables(void)
       struct retro_variable pk2var = { "mupen64-pak2" };
       if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &pk2var) && pk2var.value)
       {
-         int p2_pak = 0;
+         int p2_pak = PLUGIN_NONE;
          if (!strcmp(pk2var.value, "rumble"))
             p2_pak = PLUGIN_RAW;
          else if (!strcmp(pk2var.value, "memory"))
             p2_pak = PLUGIN_MEMPAK;
-         else
-            p2_pak = PLUGIN_NONE;
             
          if (controller[1].control)
             controller[1].control->Plugin = p2_pak;
@@ -345,13 +344,11 @@ void update_variables(void)
       struct retro_variable pk3var = { "mupen64-pak3" };
       if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &pk3var) && pk3var.value)
       {
-         int p3_pak = 0;
+         int p3_pak = PLUGIN_NONE;
          if (!strcmp(pk3var.value, "rumble"))
             p3_pak = PLUGIN_RAW;
          else if (!strcmp(pk3var.value, "memory"))
             p3_pak = PLUGIN_MEMPAK;
-         else
-            p3_pak = PLUGIN_NONE;
             
          if (controller[2].control)
             controller[2].control->Plugin = p3_pak;
@@ -365,13 +362,11 @@ void update_variables(void)
       struct retro_variable pk4var = { "mupen64-pak4" };
       if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &pk4var) && pk4var.value)
       {
-         int p4_pak = 0;
+         int p4_pak = PLUGIN_NONE;
          if (!strcmp(pk4var.value, "rumble"))
             p4_pak = PLUGIN_RAW;
          else if (!strcmp(pk4var.value, "memory"))
             p4_pak = PLUGIN_MEMPAK;
-         else
-            p4_pak = PLUGIN_NONE;
             
          if (controller[3].control)
             controller[3].control->Plugin = p4_pak;

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -21,6 +21,8 @@ retro_input_state_t input_cb = NULL;
 retro_audio_sample_batch_t audio_batch_cb = NULL;
 retro_environment_t environ_cb = NULL;
 
+struct retro_rumble_interface rumble;
+
 static struct retro_hw_render_callback render_iface;
 static cothread_t main_thread;
 static cothread_t emulator_thread;
@@ -41,6 +43,15 @@ static uint32_t game_size;
 static enum gfx_plugin_type gfx_plugin;
 static uint32_t screen_width;
 static uint32_t screen_height;
+
+// argh ugly horrible hacks kill them with fire
+extern struct
+{
+    CONTROL *control;
+    BUTTONS buttons;
+} controller[4];
+
+int pad_pak_types[4];
 
 static void n64DebugCallback(void* aContext, int aLevel, const char* aMessage)
 {
@@ -163,6 +174,14 @@ void retro_set_environment(retro_environment_t cb)
 #else
          "CPU Core; cached_interpreter|pure_interpreter" },
 #endif
+      {"mupen64-pak1",
+        "Player 1 Pak; none|rumble|memory"},
+      {"mupen64-pak2",
+        "Player 2 Pak; none|rumble|memory"},
+      {"mupen64-pak3",
+        "Player 3 Pak; none|rumble|memory"},
+      {"mupen64-pak4",
+        "Player 4 Pak; none|rumble|memory"},
       { "mupen64-disableexpmem",
          "Disable Expansion RAM; no|yes" },
       { "mupen64-gfxplugin",
@@ -228,6 +247,8 @@ void retro_init(void)
     audio_out_buffer_float = malloc(4096 * sizeof(float));
     audio_out_buffer_s16 = malloc(4096 * sizeof(int16_t));
     audio_convert_init_simd();
+    
+    environ_cb(RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE, &rumble);
 }
 
 void retro_deinit(void)
@@ -276,6 +297,84 @@ void update_variables(void)
       else if (!strcmp(var.value, "no"))
          frame_dupe = false;
    }
+   
+   
+   {
+      struct retro_variable pk1var = { "mupen64-pak1" };
+      if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &pk1var) && pk1var.value)
+      {
+         int p1_pak = 0;
+         if (!strcmp(pk1var.value, "rumble"))
+            p1_pak = PLUGIN_RAW;
+         else if (!strcmp(pk1var.value, "memory"))
+            p1_pak = PLUGIN_MEMPAK;
+         
+         // If controller struct is not initialised yet, set pad_pak_types instead
+         // which will be looked at when initialising the controllers.
+         if (controller[0].control)
+            controller[0].control->Plugin = p1_pak;
+         else
+            pad_pak_types[0] = p1_pak;
+         
+      }
+   }
+
+   {
+      struct retro_variable pk2var = { "mupen64-pak2" };
+      if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &pk2var) && pk2var.value)
+      {
+         int p2_pak = 0;
+         if (!strcmp(pk2var.value, "rumble"))
+            p2_pak = PLUGIN_RAW;
+         else if (!strcmp(pk2var.value, "memory"))
+            p2_pak = PLUGIN_MEMPAK;
+            
+         if (controller[1].control)
+            controller[1].control->Plugin = p2_pak;
+         else
+            pad_pak_types[1] = p2_pak;
+         
+      }
+   }
+   
+   {
+      struct retro_variable pk3var = { "mupen64-pak3" };
+      if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &pk3var) && pk3var.value)
+      {
+         int p3_pak = 0;
+         if (!strcmp(pk3var.value, "rumble"))
+            p3_pak = PLUGIN_RAW;
+         else if (!strcmp(pk3var.value, "memory"))
+            p3_pak = PLUGIN_MEMPAK;
+            
+         if (controller[2].control)
+            controller[2].control->Plugin = p3_pak;
+         else
+            pad_pak_types[2] = p3_pak;
+         
+      }
+   }
+  
+   {
+      struct retro_variable pk4var = { "mupen64-pak4" };
+      if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &pk4var) && pk4var.value)
+      {
+         int p4_pak = 0;
+         if (!strcmp(pk4var.value, "rumble"))
+            p4_pak = PLUGIN_RAW;
+         else if (!strcmp(pk4var.value, "memory"))
+            p4_pak = PLUGIN_MEMPAK;
+            
+         if (controller[3].control)
+            controller[3].control->Plugin = p4_pak;
+         else
+            pad_pak_types[3] = p4_pak;
+         
+      }
+   }
+   
+   
+   
 }
 
 bool retro_load_game(const struct retro_game_info *game)

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -175,13 +175,13 @@ void retro_set_environment(retro_environment_t cb)
          "CPU Core; cached_interpreter|pure_interpreter" },
 #endif
       {"mupen64-pak1",
-        "Player 1 Pak; none|rumble|memory"},
+        "Player 1 Pak; none|memory|rumble"},
       {"mupen64-pak2",
-        "Player 2 Pak; none|rumble|memory"},
+        "Player 2 Pak; none|memory|rumble"},
       {"mupen64-pak3",
-        "Player 3 Pak; none|rumble|memory"},
+        "Player 3 Pak; none|memory|rumble"},
       {"mupen64-pak4",
-        "Player 4 Pak; none|rumble|memory"},
+        "Player 4 Pak; none|memory|rumble"},
       { "mupen64-disableexpmem",
          "Disable Expansion RAM; no|yes" },
       { "mupen64-gfxplugin",
@@ -308,6 +308,8 @@ void update_variables(void)
             p1_pak = PLUGIN_RAW;
          else if (!strcmp(pk1var.value, "memory"))
             p1_pak = PLUGIN_MEMPAK;
+         else
+            p1_pak = PLUGIN_NONE;
          
          // If controller struct is not initialised yet, set pad_pak_types instead
          // which will be looked at when initialising the controllers.
@@ -328,6 +330,8 @@ void update_variables(void)
             p2_pak = PLUGIN_RAW;
          else if (!strcmp(pk2var.value, "memory"))
             p2_pak = PLUGIN_MEMPAK;
+         else
+            p2_pak = PLUGIN_NONE;
             
          if (controller[1].control)
             controller[1].control->Plugin = p2_pak;
@@ -346,6 +350,8 @@ void update_variables(void)
             p3_pak = PLUGIN_RAW;
          else if (!strcmp(pk3var.value, "memory"))
             p3_pak = PLUGIN_MEMPAK;
+         else
+            p3_pak = PLUGIN_NONE;
             
          if (controller[2].control)
             controller[2].control->Plugin = p3_pak;
@@ -364,17 +370,15 @@ void update_variables(void)
             p4_pak = PLUGIN_RAW;
          else if (!strcmp(pk4var.value, "memory"))
             p4_pak = PLUGIN_MEMPAK;
+         else
+            p4_pak = PLUGIN_NONE;
             
          if (controller[3].control)
             controller[3].control->Plugin = p4_pak;
          else
             pad_pak_types[3] = p4_pak;
-         
       }
    }
-   
-   
-   
 }
 
 bool retro_load_game(const struct retro_game_info *game)

--- a/libretro/libretro.h
+++ b/libretro/libretro.h
@@ -357,6 +357,8 @@ enum retro_mod
 
 // If set, this call is not part of the public libretro API yet. It can change or be removed at any time.
 #define RETRO_ENVIRONMENT_EXPERIMENTAL 0x10000
+// Environment callback to be used internally in frontend.
+#define RETRO_ENVIRONMENT_PRIVATE 0x20000
 
 // Environment commands.
 #define RETRO_ENVIRONMENT_SET_ROTATION  1  // const unsigned * --
@@ -445,7 +447,7 @@ enum retro_mod
                                            // If HW rendering is used, pass only RETRO_HW_FRAME_BUFFER_VALID or NULL to retro_video_refresh_t.
 #define RETRO_ENVIRONMENT_GET_VARIABLE 15
                                            // struct retro_variable * --
-                                           // Interface to aquire user-defined information from environment
+                                           // Interface to acquire user-defined information from environment
                                            // that cannot feasibly be supported in a multi-system way.
                                            // 'key' should be set to a key which has already been set by SET_VARIABLES.
                                            // 'data' will be set to a value or NULL.
@@ -487,7 +489,10 @@ enum retro_mod
                                            // NULL is returned if the libretro was loaded statically (i.e. linked statically to frontend), or if the path cannot be determined.
                                            // Mostly useful in cooperation with SET_SUPPORT_NO_GAME as assets can be loaded without ugly hacks.
                                            //
-#define RETRO_ENVIRONMENT_SET_AUDIO_CALLBACK 20
+                                           //
+// Environment 20 was an obsolete version of SET_AUDIO_CALLBACK. It was not used by any known core at the time,
+// and was removed from the API.
+#define RETRO_ENVIRONMENT_SET_AUDIO_CALLBACK 22
                                            // const struct retro_audio_callback * --
                                            // Sets an interface which is used to notify a libretro core about audio being available for writing.
                                            // The callback can be called from any thread, so a core using this must have a thread safe audio implementation.
@@ -509,13 +514,43 @@ enum retro_mod
                                            // Lets the core know how much time has passed since last invocation of retro_run().
                                            // The frontend can tamper with the timing to fake fast-forward, slow-motion, frame stepping, etc.
                                            // In this case the delta time will use the reference value in frame_time_callback..
-                                          
+                                           //
+#define RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE 23
+                                           // struct retro_rumble_interface * --
+                                           // Gets an interface which is used by a libretro core to set state of rumble motors in controllers.
+                                           // A strong and weak motor is supported, and they can be controlled indepedently.
+
+
+enum retro_rumble_effect
+{
+   RETRO_RUMBLE_STRONG = 0,
+   RETRO_RUMBLE_WEAK = 1,
+
+   RETRO_RUMBLE_DUMMY = INT_MAX
+};
+
+// Sets rumble state for joypad plugged in port 'port'. Rumble effects are controlled independently,
+// and setting e.g. strong rumble does not override weak rumble.
+// Strength has a range of [0, 0xffff].
+//
+// Returns true if rumble state request was honored. Calling this before first retro_run() is likely to return false.
+typedef bool (*retro_set_rumble_state_t)(unsigned port, enum retro_rumble_effect effect, uint16_t strength);
+struct retro_rumble_interface
+{
+   retro_set_rumble_state_t set_rumble_state;
+};
 
 // Notifies libretro that audio data should be written.
 typedef void (*retro_audio_callback_t)(void);
+
+// True: Audio driver in frontend is active, and callback is expected to be called regularily.
+// False: Audio driver in frontend is paused or inactive. Audio callback will not be called until set_state has been called with true.
+// Initial state is false (inactive).
+typedef void (*retro_audio_set_state_callback_t)(bool enabled);
 struct retro_audio_callback
 {
    retro_audio_callback_t callback;
+   retro_audio_set_state_callback_t set_state;
 };
 
 // Notifies a libretro core of time spent since last invocation of retro_run() in microseconds.
@@ -575,7 +610,7 @@ struct retro_hw_render_callback
    // The reset callback might still be called in extreme situations such as if the context is lost beyond recovery. 
    // For optimal stability, set this to false, and allow context to be reset at any time.
    retro_hw_context_reset_t context_destroy; // A callback to be called before the context is destroyed. Resources can be deinitialized at this step. This can be set to NULL, in which resources will just be destroyed without any notification.
-   bool debug_context; // Creates a debug context. Only takes effect when using GL core.
+   bool debug_context; // Creates a debug context.
 };
 
 // Callback type passed in RETRO_ENVIRONMENT_SET_KEYBOARD_CALLBACK. Called by the frontend in response to keyboard events.


### PR DESCRIPTION
Add support for the Rumble Pak using libretro's new rumble API. Also added four core options to choose the Pak (rumble or memory) attached to each pad.

A rather crude approach to modifying the controller Pak is used because we will first be called before `controller[n].control` is initialised.
