### PR TITLE
[Rice] Change some BOOL variables to actual booleans. These are ones that can be set to them safely.

### DIFF
--- a/gles2rice/src/Combiner.cpp
+++ b/gles2rice/src/Combiner.cpp
@@ -21,9 +21,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "Config.h"
 #include "RenderBase.h"
 
-//static BOOL g_bHiliteRGBAHack = FALSE;
-
-
 #ifdef DEBUGGER
 const char *constStrs[] = {
     "MUX_0",

--- a/gles2rice/src/CombinerDefs.h
+++ b/gles2rice/src/CombinerDefs.h
@@ -28,31 +28,31 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define MUX_MASK_WITH_COMP  0x9F
 enum
 {
-    MUX_0 = 0,
-    MUX_1,
-    MUX_COMBINED,
-    MUX_TEXEL0,
-    MUX_TEXEL1,
-    MUX_PRIM,
-    MUX_SHADE,
-    MUX_ENV,
-    MUX_COMBALPHA,
-    MUX_T0_ALPHA,
-    MUX_T1_ALPHA,
-    MUX_PRIM_ALPHA,
-    MUX_SHADE_ALPHA,
-    MUX_ENV_ALPHA,
-    MUX_LODFRAC,
-    MUX_PRIMLODFRAC,
-    MUX_K5,
+    MUX_0              = 0,
+    MUX_1              = 1,
+    MUX_COMBINED       = 2,
+    MUX_TEXEL0         = 3,
+    MUX_TEXEL1         = 4,
+    MUX_PRIM           = 5,
+    MUX_SHADE          = 6,
+    MUX_ENV            = 7,
+    MUX_COMBALPHA      = 8,
+    MUX_T0_ALPHA       = 9,
+    MUX_T1_ALPHA       = 10,
+    MUX_PRIM_ALPHA     = 11,
+    MUX_SHADE_ALPHA    = 12,
+    MUX_ENV_ALPHA      = 13,
+    MUX_LODFRAC        = 14,
+    MUX_PRIMLODFRAC    = 15,
+    MUX_K5             = 16,
     MUX_UNK,            //Use this if you want to factor to be set to 0
 
     // Don't change value of these three flags, then need to be within 1 uint8
-    MUX_NEG             = 0x20, //Support by NVidia register combiner
+    MUX_NEG            = 0x20, //Support by NVidia register combiner
     MUX_ALPHAREPLICATE = 0x40,
-    MUX_COMPLEMENT = 0x80,
-    MUX_FORCE_0 = 0xFE,
-    MUX_ERR = 0xFF,
+    MUX_COMPLEMENT     = 0x80,
+    MUX_FORCE_0        = 0xFE,
+    MUX_ERR            = 0xFF,
 };
 
 

--- a/gles2rice/src/CombinerDefs.h
+++ b/gles2rice/src/CombinerDefs.h
@@ -26,6 +26,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define MUX_MASK_WITH_ALPHA 0x5F
 #define MUX_MASK_WITH_NEG   0x3F
 #define MUX_MASK_WITH_COMP  0x9F
+
+// Combiner constants
 enum
 {
     MUX_0              = 0,

--- a/gles2rice/src/Config.cpp
+++ b/gles2rice/src/Config.cpp
@@ -1159,7 +1159,7 @@ void WriteIniFile()
             nextline++;
         if (thisline[0] == '{')
         {
-            BOOL bFound = FALSE;
+            bool bFound = false;
             // Start of section
             tidy((char*) thisline);
             thisline[strlen(thisline) - 1] = '\0';
@@ -1172,7 +1172,7 @@ void WriteIniFile()
                     // Output this CRC
                     OutputSectionDetails(i, fhOut);
                     IniSections[i].bOutput = true;
-                    bFound = TRUE;
+                    bFound = true;
                     break;
                 }
             }

--- a/gles2rice/src/GraphicsContext.cpp
+++ b/gles2rice/src/GraphicsContext.cpp
@@ -57,15 +57,15 @@ void CGraphicsContext::InitWindowInfo()
 {
 }
 
-bool CGraphicsContext::Initialize(uint32 dwWidth, uint32 dwHeight, BOOL bWindowed)
+bool CGraphicsContext::Initialize(uint32 dwWidth, uint32 dwHeight, bool bWindowed)
 {
-    m_bWindowed = (bWindowed != 0);
+    m_bWindowed = bWindowed;
 
     g_pFrameBufferManager->Initialize();
     return true;
 }
 
-bool CGraphicsContext::ResizeInitialize(uint32 dwWidth, uint32 dwHeight, BOOL bWindowed )
+bool CGraphicsContext::ResizeInitialize(uint32 dwWidth, uint32 dwHeight, bool bWindowed )
 {
     return true;
 }

--- a/gles2rice/src/GraphicsContext.h
+++ b/gles2rice/src/GraphicsContext.h
@@ -56,8 +56,8 @@ public:
     bool Ready() { return m_bReady; }
     bool IsWindowed() {return m_bWindowed;}
 
-    virtual bool Initialize(uint32 dwWidth, uint32 dwHeight, BOOL bWindowed );
-    virtual bool ResizeInitialize(uint32 dwWidth, uint32 dwHeight, BOOL bWindowed );
+    virtual bool Initialize(uint32 dwWidth, uint32 dwHeight, bool bWindowed );
+    virtual bool ResizeInitialize(uint32 dwWidth, uint32 dwHeight, bool bWindowed );
     virtual void CleanUp();
 
     virtual void Clear(ClearFlag flags, uint32 color=0xFF000000, float depth=1.0f) = 0;

--- a/gles2rice/src/OGLCombiner.cpp
+++ b/gles2rice/src/OGLCombiner.cpp
@@ -98,7 +98,7 @@ void COGLColorCombiner::DisableCombiner(void)
         COGLTexture* pTexture = g_textures[gRSP.curTile].m_pCOGLTexture;
         if( pTexture ) 
         {
-            m_pOGLRender->EnableTexUnit(0,TRUE);
+            m_pOGLRender->EnableTexUnit(0, true);
             m_pOGLRender->BindTexture(pTexture->m_dwTextureName, 0);
             glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
             OPENGL_CHECK_ERRORS;
@@ -115,14 +115,14 @@ void COGLColorCombiner::DisableCombiner(void)
     {
         glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
         OPENGL_CHECK_ERRORS;
-        m_pOGLRender->EnableTexUnit(0,FALSE);
+        m_pOGLRender->EnableTexUnit(0, false);
     }
 }
 
 void COGLColorCombiner::InitCombinerCycleCopy(void)
 {
     m_pOGLRender->DisableMultiTexture();
-    m_pOGLRender->EnableTexUnit(0,TRUE);
+    m_pOGLRender->EnableTexUnit(0, true);
     COGLTexture* pTexture = g_textures[gRSP.curTile].m_pCOGLTexture;
     if( pTexture )
     {
@@ -143,7 +143,7 @@ void COGLColorCombiner::InitCombinerCycleCopy(void)
 void COGLColorCombiner::InitCombinerCycleFill(void)
 {
     m_pOGLRender->DisableMultiTexture();
-    m_pOGLRender->EnableTexUnit(0,FALSE);
+    m_pOGLRender->EnableTexUnit(0, false);
 }
 
 
@@ -154,7 +154,7 @@ void COGLColorCombiner::InitCombinerCycle12(void)
     {
         glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
         OPENGL_CHECK_ERRORS;
-        m_pOGLRender->EnableTexUnit(0,FALSE);
+        m_pOGLRender->EnableTexUnit(0, false);
         return;
     }
 
@@ -163,7 +163,7 @@ void COGLColorCombiner::InitCombinerCycle12(void)
     COGLTexture* pTexture = g_textures[gRSP.curTile].m_pCOGLTexture;
     if( pTexture )
     {
-        m_pOGLRender->EnableTexUnit(0,TRUE);
+        m_pOGLRender->EnableTexUnit(0, true);
         m_pOGLRender->BindTexture(pTexture->m_dwTextureName, 0);
         m_pOGLRender->SetAllTexelRepeatFlag();
     }
@@ -325,7 +325,7 @@ void COGLColorCombiner::InitCombinerBlenderForSimpleTextureDraw(uint32 tile)
     m_pOGLRender->DisableMultiTexture();
     if( g_textures[tile].m_pCTexture )
     {
-        m_pOGLRender->EnableTexUnit(0,TRUE);
+        m_pOGLRender->EnableTexUnit(0, true);
         glBindTexture(GL_TEXTURE_2D, ((COGLTexture*)(g_textures[tile].m_pCTexture))->m_dwTextureName);
         OPENGL_CHECK_ERRORS;
     }

--- a/gles2rice/src/OGLCombinerTNT2.cpp
+++ b/gles2rice/src/OGLCombinerTNT2.cpp
@@ -210,7 +210,7 @@ void COGLColorCombinerTNT2::GenerateCombinerSetting(int index)
     // Texture unit 0
     pglActiveTexture(GL_TEXTURE0_ARB);
     glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_COMBINE4_NV);
-    m_pOGLRender->EnableTexUnit(0,TRUE);
+    m_pOGLRender->EnableTexUnit(0, true);
     glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_RGB_ARB, res.unit1.rgbOp);
     glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_ALPHA_ARB, res.unit1.alphaOp);
 
@@ -286,11 +286,11 @@ void COGLColorCombinerTNT2::GenerateCombinerSetting(int index)
         glTexEnvi(GL_TEXTURE_ENV, GL_SOURCE3_ALPHA_EXT, MapRGBArgs(res.unit2.alphaArg3));
         glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND3_ALPHA_EXT, MapAlphaArgFlags(res.unit2.alphaArg3));
 
-        m_pOGLRender->EnableTexUnit(1,TRUE);
+        m_pOGLRender->EnableTexUnit(1, true);
     }
     else
     {
-        //m_pOGLRender->EnableTexUnit(1,FALSE);
+        //m_pOGLRender->EnableTexUnit(1, false);
     }
 }
 

--- a/gles2rice/src/OGLES2FragmentShaders.cpp
+++ b/gles2rice/src/OGLES2FragmentShaders.cpp
@@ -330,7 +330,7 @@ void COGL_FragmentProgramCombiner::DisableCombiner(void)
 void COGL_FragmentProgramCombiner::InitCombinerCycleCopy(void)
 {
     m_pOGLRender->DisableMultiTexture();
-    m_pOGLRender->EnableTexUnit(0,TRUE);
+    m_pOGLRender->EnableTexUnit(0, true);
     glUseProgram(copyProgram);
     glUniform1f(copyAlphaLocation,m_AlphaRef);
     OPENGL_CHECK_ERRORS;

--- a/gles2rice/src/OGLExtCombiner.cpp
+++ b/gles2rice/src/OGLExtCombiner.cpp
@@ -136,13 +136,13 @@ void COGLColorCombiner4::InitCombinerCycleFill(void)
     {
         pglActiveTexture(GL_TEXTURE0_ARB+i);
         OPENGL_CHECK_ERRORS;
-        m_pOGLRender->EnableTexUnit(i,FALSE);
+        m_pOGLRender->EnableTexUnit(i, false);
     }
 
     //pglActiveTexture(GL_TEXTURE0_ARB);
-    //m_pOGLRender->EnableTexUnit(0,FALSE);
+    //m_pOGLRender->EnableTexUnit(0, false);
     //pglActiveTexture(GL_TEXTURE1_ARB);
-    //m_pOGLRender->EnableTexUnit(1,FALSE);
+    //m_pOGLRender->EnableTexUnit(1, false);
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -969,7 +969,7 @@ void COGLColorCombiner4::GenerateCombinerSetting(int index)
     {
         pglActiveTexture(GL_TEXTURE0_ARB+i);
         OPENGL_CHECK_ERRORS;
-        m_pOGLRender->EnableTexUnit(i,TRUE);
+        m_pOGLRender->EnableTexUnit(i, true);
         glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_COMBINE_ARB);
         OPENGL_CHECK_ERRORS;
         ApplyFor1Unit(res.units[i]);
@@ -982,7 +982,7 @@ void COGLColorCombiner4::GenerateCombinerSetting(int index)
             pglActiveTexture(GL_TEXTURE0_ARB+i);
             OPENGL_CHECK_ERRORS;
             m_pOGLRender->DisBindTexture(0, i);
-            m_pOGLRender->EnableTexUnit(i,FALSE);
+            m_pOGLRender->EnableTexUnit(i, false);
         }
     }
 }
@@ -1054,7 +1054,7 @@ void COGLColorCombiner4v2::GenerateCombinerSettingConstants(int index)
         // Set Texture unit 2 to ENV
         pglActiveTexture(GL_TEXTURE2_ARB);
         OPENGL_CHECK_ERRORS;
-        prender->EnableTexUnit(2,TRUE);
+        prender->EnableTexUnit(2, true);
         TxtrCacheEntry *pEntry = gTextureManager.GetConstantColorTexture(MUX_ENV);
         prender->SetCurrentTexture( (gRSP.curTile+2)%7, pEntry->pTexture, 4, 4, pEntry);
         prender->SetTexelRepeatFlags((gRSP.curTile+2)%7);
@@ -1069,7 +1069,7 @@ void COGLColorCombiner4v2::GenerateCombinerSettingConstants(int index)
         // Set Texture unit 3 to LODFRAC
         pglActiveTexture(GL_TEXTURE0_ARB+unit);
         OPENGL_CHECK_ERRORS;
-        prender->EnableTexUnit(unit,TRUE);
+        prender->EnableTexUnit(unit, true);
         TxtrCacheEntry *pEntry = gTextureManager.GetConstantColorTexture(MUX_LODFRAC);
         prender->SetCurrentTexture( (gRSP.curTile+unit)%7, pEntry->pTexture, 4, 4, pEntry);
         prender->SetTexelRepeatFlags((gRSP.curTile+unit)%7);
@@ -1083,7 +1083,7 @@ void COGLColorCombiner4v2::GenerateCombinerSettingConstants(int index)
         // Disable texture unit 3
         pglActiveTexture(GL_TEXTURE0_ARB+unit);
         OPENGL_CHECK_ERRORS;
-        prender->EnableTexUnit(unit,FALSE);
+        prender->EnableTexUnit(unit, false);
         prender->SetTextureToTextureUnitMap(-1,unit);
     }
 }
@@ -1223,16 +1223,16 @@ void COGLColorCombiner2::GenerateCombinerSetting(int index)
         //if(res.units[i].textureIsUsed)
         {
             prender->SetTextureToTextureUnitMap(res.units[i].tex,i);
-            m_pOGLRender->EnableTexUnit(i,TRUE);
+            m_pOGLRender->EnableTexUnit(i, true);
             COGLTexture* pTexture = g_textures[(gRSP.curTile+res.units[i].tex)&7].m_pCOGLTexture;
             if( pTexture )  m_pOGLRender->BindTexture(pTexture->m_dwTextureName, i);
         }
         /*
         else
         {
-            m_pOGLRender->EnableTexUnit(i,TRUE);
+            m_pOGLRender->EnableTexUnit(i, true);
             prender->SetTextureToTextureUnitMap(-1,i);
-            //m_pOGLRender->EnableTexUnit(i,FALSE);
+            //m_pOGLRender->EnableTexUnit(i, false);
             //m_pOGLRender->DisBindTexture(0, i);
         }
         */
@@ -1248,7 +1248,7 @@ void COGLColorCombiner2::GenerateCombinerSetting(int index)
         {
             pglActiveTextureARB(GL_TEXTURE0_ARB+i);
             OPENGL_CHECK_ERRORS;
-            m_pOGLRender->EnableTexUnit(i,FALSE);
+            m_pOGLRender->EnableTexUnit(i, false);
             prender->SetTextureToTextureUnitMap(-1,i);
         }
     }

--- a/gles2rice/src/OGLExtRender.cpp
+++ b/gles2rice/src/OGLExtRender.cpp
@@ -178,7 +178,7 @@ void COGLExtRender::SetTextureUFlag(TextureUVFlag dwFlag, uint32 dwTile)
             COGLTexture* pTexture = g_textures[(gRSP.curTile+tex)&7].m_pCOGLTexture;
             if( pTexture ) 
             {
-                EnableTexUnit(textureNo,TRUE);
+                EnableTexUnit(textureNo, true);
                 BindTexture(pTexture->m_dwTextureName, textureNo);
             }
             SetTexWrapS(textureNo, OGLXUVFlagMaps[dwFlag].realFlag);
@@ -219,7 +219,7 @@ void COGLExtRender::SetTextureVFlag(TextureUVFlag dwFlag, uint32 dwTile)
             COGLTexture* pTexture = g_textures[(gRSP.curTile+tex)&7].m_pCOGLTexture;
             if( pTexture )
             {
-                EnableTexUnit(textureNo,TRUE);
+                EnableTexUnit(textureNo, true);
                 BindTexture(pTexture->m_dwTextureName, textureNo);
             }
             SetTexWrapT(textureNo, OGLXUVFlagMaps[dwFlag].realFlag);
@@ -227,14 +227,14 @@ void COGLExtRender::SetTextureVFlag(TextureUVFlag dwFlag, uint32 dwTile)
     }
 }
 
-void COGLExtRender::EnableTexUnit(int unitno, BOOL flag)
+void COGLExtRender::EnableTexUnit(int unitno, bool flag)
 {
     if( m_texUnitEnabled[unitno] != flag )
     {
         m_texUnitEnabled[unitno] = flag;
         pglActiveTexture(GL_TEXTURE0_ARB+unitno);
         OPENGL_CHECK_ERRORS;
-        if( flag == TRUE )
+        if( flag )
             glEnable(GL_TEXTURE_2D);
         else
             glDisable(GL_TEXTURE_2D);

--- a/gles2rice/src/OGLExtRender.h
+++ b/gles2rice/src/OGLExtRender.h
@@ -31,7 +31,7 @@ public:
     void TexCoord(TLITVERTEX &vtxInfo);
     void SetTextureUFlag(TextureUVFlag dwFlag, uint32 tile);
     void SetTextureVFlag(TextureUVFlag dwFlag, uint32 tile);
-    void EnableTexUnit(int unitno, BOOL flag);
+    void EnableTexUnit(int unitno, bool flag);
     void SetTexWrapS(int unitno,GLuint flag);
     void SetTexWrapT(int unitno,GLuint flag);
     void ApplyTextureFilter();

--- a/gles2rice/src/OGLGraphicsContext.cpp
+++ b/gles2rice/src/OGLGraphicsContext.cpp
@@ -58,7 +58,7 @@ COGLGraphicsContext::~COGLGraphicsContext()
 {
 }
 
-bool COGLGraphicsContext::Initialize(uint32 dwWidth, uint32 dwHeight, BOOL bWindowed )
+bool COGLGraphicsContext::Initialize(uint32 dwWidth, uint32 dwHeight, bool bWindowed )
 {
     DebugMessage(M64MSG_INFO, "Initializing OpenGL Device Context.");
     Lock();
@@ -168,7 +168,7 @@ bool COGLGraphicsContext::Initialize(uint32 dwWidth, uint32 dwHeight, BOOL bWind
     return true;
 }
 
-bool COGLGraphicsContext::ResizeInitialize(uint32 dwWidth, uint32 dwHeight, BOOL bWindowed )
+bool COGLGraphicsContext::ResizeInitialize(uint32 dwWidth, uint32 dwHeight, bool bWindowed )
 {
     Lock();
 

--- a/gles2rice/src/OGLGraphicsContext.h
+++ b/gles2rice/src/OGLGraphicsContext.h
@@ -29,8 +29,8 @@ class COGLGraphicsContext : public CGraphicsContext
 public:
     virtual ~COGLGraphicsContext();
 
-    bool Initialize(uint32 dwWidth, uint32 dwHeight, BOOL bWindowed );
-    bool ResizeInitialize(uint32 dwWidth, uint32 dwHeight, BOOL bWindowed );
+    bool Initialize(uint32 dwWidth, uint32 dwHeight, bool bWindowed );
+    bool ResizeInitialize(uint32 dwWidth, uint32 dwHeight, bool bWindowed );
     void CleanUp();
     void Clear(ClearFlag dwFlags, uint32 color=0xFF000000, float depth=1.0f);
 

--- a/gles2rice/src/OGLRender.cpp
+++ b/gles2rice/src/OGLRender.cpp
@@ -540,7 +540,7 @@ void OGLRender::SetTextureUFlag(TextureUVFlag dwFlag, uint32 dwTile)
         COGLTexture* pTexture = g_textures[gRSP.curTile].m_pCOGLTexture;
         if( pTexture )
         {
-            EnableTexUnit(0,TRUE);
+            EnableTexUnit(0, true);
             BindTexture(pTexture->m_dwTextureName, 0);
         }
         SetTexWrapS(0, OGLXUVFlagMaps[dwFlag].realFlag);
@@ -554,7 +554,7 @@ void OGLRender::SetTextureVFlag(TextureUVFlag dwFlag, uint32 dwTile)
         COGLTexture* pTexture = g_textures[gRSP.curTile].m_pCOGLTexture;
         if( pTexture ) 
         {
-            EnableTexUnit(0,TRUE);
+            EnableTexUnit(0, true);
             BindTexture(pTexture->m_dwTextureName, 0);
         }
         SetTexWrapT(0, OGLXUVFlagMaps[dwFlag].realFlag);
@@ -961,7 +961,7 @@ void OGLRender::DrawSimpleRect(int nX0, int nY0, int nX1, int nY1, uint32 dwColo
 void OGLRender::InitCombinerBlenderForSimpleRectDraw(uint32 tile)
 {
     //glEnable(GL_CULL_FACE);
-    EnableTexUnit(0,FALSE);
+    EnableTexUnit(0, false);
     OPENGL_CHECK_ERRORS;
     glEnable(GL_BLEND);
     OPENGL_CHECK_ERRORS;
@@ -1061,23 +1061,23 @@ void OGLRender::BindTexture(GLuint texture, int unitno)
 
 void OGLRender::DisBindTexture(GLuint texture, int unitno)
 {
-    //EnableTexUnit(0,FALSE);
+    //EnableTexUnit(0, false);
     //glBindTexture(GL_TEXTURE_2D, 0);  //Not to bind any texture
 }
 
-void OGLRender::EnableTexUnit(int unitno, BOOL flag)
+void OGLRender::EnableTexUnit(int unitno, bool flag)
 {
 #ifdef DEBUGGER
     if( unitno != 0 )
     {
-        DebuggerAppendMsg("Check me, in the base ogl render, unitno!=0");
+        DebuggerAppendMsg("Check me, in the base OpenGL render, unitno!=0");
     }
 #endif
     if( m_texUnitEnabled[0] != flag )
     {
         m_texUnitEnabled[0] = flag;
 #if SDL_VIDEO_OPENGL
-        if( flag == TRUE )
+        if( flag )
             glEnable(GL_TEXTURE_2D);
         else
             glDisable(GL_TEXTURE_2D);
@@ -1131,7 +1131,8 @@ void OGLRender::UpdateScissor()
 
 void OGLRender::ApplyRDPScissor(bool force)
 {
-    if( !force && status.curScissor == RDP_SCISSOR )    return;
+    if( !force && status.curScissor == RDP_SCISSOR )
+        return;
 
     if( options.bEnableHacks && g_CI.dwWidth == 0x200 && gRDP.scissor.right == 0x200 && g_CI.dwWidth>(*g_GraphicsInfo.VI_WIDTH_REG & 0xFFF) )
     {
@@ -1156,7 +1157,8 @@ void OGLRender::ApplyRDPScissor(bool force)
 
 void OGLRender::ApplyScissorWithClipRatio(bool force)
 {
-    if( !force && status.curScissor == RSP_SCISSOR )    return;
+    if( !force && status.curScissor == RSP_SCISSOR )
+        return;
 
     glEnable(GL_SCISSOR_TEST);
     OPENGL_CHECK_ERRORS;
@@ -1247,13 +1249,13 @@ void OGLRender::DisableMultiTexture()
 {
     pglActiveTexture(GL_TEXTURE1_ARB);
     OPENGL_CHECK_ERRORS;
-    EnableTexUnit(1,FALSE);
+    EnableTexUnit(1, false);
     pglActiveTexture(GL_TEXTURE0_ARB);
     OPENGL_CHECK_ERRORS;
-    EnableTexUnit(0,FALSE);
+    EnableTexUnit(0, false);
     pglActiveTexture(GL_TEXTURE0_ARB);
     OPENGL_CHECK_ERRORS;
-    EnableTexUnit(0,TRUE);
+    EnableTexUnit(0, true);
 }
 
 void OGLRender::EndRendering(void)

--- a/gles2rice/src/OGLRender.h
+++ b/gles2rice/src/OGLRender.h
@@ -87,7 +87,7 @@ public:
     void EndRendering(void);
 
     void glViewportWrapper(GLint x, GLint y, GLsizei width, GLsizei height, bool flag=true);
-    virtual void EnableTexUnit(int unitno, BOOL flag);
+    virtual void EnableTexUnit(int unitno, bool flag);
     virtual void SetTexWrapS(int unitno,GLuint flag);
     virtual void SetTexWrapT(int unitno,GLuint flag);
 

--- a/gles2rice/src/RSP_GBI2.h
+++ b/gles2rice/src/RSP_GBI2.h
@@ -620,17 +620,17 @@ void RSP_GBI2_GeometryMode(Gfx *gfx)
     bool bCullFront     = (gRDP.geometryMode & RSP_ZELDA_CULL_FRONT) ? true : false;
     bool bCullBack      = (gRDP.geometryMode & RSP_ZELDA_CULL_BACK) ? true : false;
     
-    //BOOL bShade         = (gRDP.geometryMode & G_SHADE) ? TRUE : FALSE;
-    //BOOL bFlatShade     = (gRDP.geometryMode & RSP_ZELDA_SHADING_SMOOTH) ? TRUE : FALSE;
-    BOOL bFlatShade     = (gRDP.geometryMode & RSP_ZELDA_TEXTURE_GEN_LINEAR) ? TRUE : FALSE;
+    //bool bShade         = (gRDP.geometryMode & G_SHADE) ? true : false;
+    //bool bFlatShade     = (gRDP.geometryMode & RSP_ZELDA_SHADING_SMOOTH) ? true : false;
+    bool bFlatShade     = (gRDP.geometryMode & RSP_ZELDA_TEXTURE_GEN_LINEAR) ? true : false;
     if( options.enableHackForGames == HACK_FOR_TIGER_HONEY_HUNT )
-        bFlatShade      = FALSE;
+        bFlatShade      = false;
     
     bool bFog           = (gRDP.geometryMode & RSP_ZELDA_FOG) ? true : false;
     bool bTextureGen    = (gRDP.geometryMode & RSP_ZELDA_TEXTURE_GEN) ? true : false;
 
     bool bLighting      = (gRDP.geometryMode & RSP_ZELDA_LIGHTING) ? true : false;
-    BOOL bZBuffer       = (gRDP.geometryMode & RSP_ZELDA_ZBUFFER)  ? TRUE : FALSE; 
+    bool bZBuffer       = (gRDP.geometryMode & RSP_ZELDA_ZBUFFER)  ? true : false; 
 
     CRender::g_pRender->SetCullMode(bCullFront, bCullBack);
     

--- a/gles2rice/src/RSP_GBI_Others.h
+++ b/gles2rice/src/RSP_GBI_Others.h
@@ -618,13 +618,12 @@ void RSP_Tri4_PD(Gfx *gfx)
         uint32 dwFlag = (w0>>16)&0xFF;
         LOG_UCODE("    PD Tri4: 0x%08x 0x%08x Flag: 0x%02x", w0, w1, dwFlag);
 
-        BOOL bVisible;
         for( uint32 i=0; i<4; i++)
         {
             uint32 v0 = (w1>>(4+(i<<3))) & 0xF;
             uint32 v1 = (w1>>(  (i<<3))) & 0xF;
             uint32 v2 = (w0>>(  (i<<2))) & 0xF;
-            bVisible = IsTriangleVisible(v0, v2, v1);
+            bool bVisible = IsTriangleVisible(v0, v2, v1);
             LOG_UCODE("       (%d, %d, %d) %s", v0, v1, v2, bVisible ? "": "(clipped)");
             if (bVisible)
             {

--- a/gles2rice/src/RSP_Parser.cpp
+++ b/gles2rice/src/RSP_Parser.cpp
@@ -781,7 +781,6 @@ extern bool bHalfTxtScale;
 void DLParser_Process(OSTask * pTask)
 {
     static int skipframe=0;
-    //BOOL menuWaiting = FALSE;
 
     dlistMtxCount = 0;
     bHalfTxtScale = false;
@@ -946,6 +945,7 @@ void RDP_NOIMPL_WARN(const char* op)
 
 void RSP_GBI1_Noop(Gfx *gfx)
 {
+    // Do nothing. (It is a no-op after all).
 }
 
 
@@ -980,8 +980,8 @@ void RSP_GFX_InitGeometryMode()
     }
     CRender::g_pRender->SetCullMode(bCullFront, bCullBack);
     
-    BOOL bShade         = (gRDP.geometryMode & G_SHADE) ? TRUE : FALSE;
-    BOOL bShadeSmooth   = (gRDP.geometryMode & G_SHADING_SMOOTH) ? TRUE : FALSE;
+    bool bShade         = (gRDP.geometryMode & G_SHADE) ? true : false;
+    bool bShadeSmooth   = (gRDP.geometryMode & G_SHADING_SMOOTH) ? true : false;
     if (bShade && bShadeSmooth)     CRender::g_pRender->SetShadeMode( SHADE_SMOOTH );
     else                            CRender::g_pRender->SetShadeMode( SHADE_FLAT );
     

--- a/gles2rice/src/RSP_S2DEX.h
+++ b/gles2rice/src/RSP_S2DEX.h
@@ -40,163 +40,176 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define S2DEX_BGLT_LOADBLOCK    0x0033
 #define S2DEX_BGLT_LOADTILE     0xfff4
 
-typedef struct  {       //Intel format
-  uint32    type;   
-  uint32    image;
+typedef struct //Intel Format
+{
+  uint32    type;  // Struct classification type. Should always be 0x1033
+  uint32    image; // Texture address within the DRAM.
+
+  uint16    tmem;  // TMEM load address
+  uint16    tsize; // Texture size
+  uint16    tline; // Texture line width for one line.
+
+  uint16    sid;   // State ID
+  uint32    flag;  // State flag
+  uint32    mask;  // State mask
+} uObjTxtrBlock;
+
+typedef struct //Intel Format
+{
+  uint32    type;    // Struct classification type. Should always be 0xfc1034
+  uint32    image;   // Texture address within the DRAM.
+
+  uint16    tmem;    // TMEM load address
+  uint16    twidth;  // Texture width
+  uint16    theight; // Texture height
+
+  uint16    sid;     // State ID. Always a multiple of 4. Can be 0, 4, 8, or 12.
+  uint32    flag;    // State flag
+  uint32    mask;    // State mask
   
-  uint16    tsize;  
-  uint16    tmem;   
+} uObjTxtrTile;      // 24 bytes
+
+typedef struct // Intel Format
+{
+  uint32    type;  // Struct classification type, should always be 0x30
+  uint32    image; // Texture address within the DRAM.
   
-  uint16    sid;    
-  uint16    tline;  
-
-  uint32    flag;   
-  uint32    mask;   
-} uObjTxtrBlock;    
-
-typedef struct  {       //Intel Format
-  uint32    type;   
-  uint32    image;
-
-  uint16    twidth; 
-  uint16    tmem;   
-
-  uint16    sid;    
-  uint16    theight;
-
-  uint32    flag;   
-  uint32    mask;   
-} uObjTxtrTile;         // 24 bytes
-
-typedef struct  {       // Intel Format
-  uint32    type;   
-  uint32    image;
+  uint16    pnum;  // Loaded palette number - 1
+  uint16    phead; // Number indicating the first loaded palette.
   
-  uint16    pnum;   
-  uint16    phead;  
+  uint16    zero;  // Always 0
   
-  uint16    sid;    
-  uint16   zero;    
+  uint16    sid;   // State ID. Always a multiple of 4. Can be 0, 4, 8, or 12.
+  uint32    flag;  // State flag
+  uint32    mask;  // State mask
   
-  uint32    flag;   
-  uint32    mask;   
-} uObjTxtrTLUT;     
+} uObjTxtrTLUT;    // 24 bytes
 
-typedef union {
-  uObjTxtrBlock      block;
-  uObjTxtrTile       tile;
-  uObjTxtrTLUT       tlut;
+typedef union
+{
+  uObjTxtrBlock  block;
+  uObjTxtrTile   tile;
+  uObjTxtrTLUT   tlut;
 } uObjTxtr;
 
-typedef struct {        // Intel format
-  uint16  scaleW;       
-  short  objX;          
+typedef struct // Intel format
+{
+  uint16  scaleW;      // X-axis scale factor.
+  short   objX;        // X-coordinate of the upper-left position of the sprite.
   
-  uint16  paddingX;     
-  uint16  imageW;       
+  uint16  paddingX;    // Unused, always 0.
+  uint16  imageW;      // Texture width
   
-  uint16  scaleH;       
-  short  objY;          
+  uint16  scaleH;      // Y-axis scale factor.
+  short   objY;        // Y-coordinate of the upper-left position of the sprite.
   
-  uint16  paddingY;     
-  uint16  imageH;       
+  uint16  paddingY;    // Unused, always 0.
+  uint16  imageH;      // Texture height
   
-  uint16  imageAdrs;    
-  uint16  imageStride;  
+  uint16  imageAdrs;   // Texture address within the TMEM.
+  uint16  imageStride; // Number of bytes from one row of pixels in memory to the next row of pixels (ie. Stride)
 
-  uint8   imageFlags;   
-  uint8   imagePal;     
-  uint8   imageSiz;     
-  uint8   imageFmt;     
-} uObjSprite;           
+  uint8   imageFlags;  // Flag used for image manipulations
+  uint8   imagePal;    // Palette number. Can be from 0 - 7
+  uint8   imageSiz;    // Texel size
+  uint8   imageFmt;    // Texel format
+} uObjSprite;
 
 
-typedef struct  {
-  uObjTxtr  txtr;
+typedef struct 
+{
+  uObjTxtr      txtr;
   uObjSprite    sprite;
 } uObjTxSprite;     /* 48 bytes */
 
-typedef struct {        // Intel format
-  s32       A, B, C, D; 
+typedef struct // Intel format
+{
+  s32       A, B, C, D;
 
-  short     Y;          
-  short     X;          
+  short     Y;
+  short     X;
 
-  uint16   BaseScaleY;  
-  uint16   BaseScaleX;  
-} uObjMtx;              
+  uint16   BaseScaleY;
+  uint16   BaseScaleX;
+} uObjMtx;
 
-typedef struct {
+typedef struct  //Intel format
+{
   float   A, B, C, D;
-  float   X;        
-  float   Y;        
+  float   X;
+  float   Y;
   float   BaseScaleX;
   float   BaseScaleY;
 } uObjMtxReal;
 
-typedef struct {        //Intel format
-  short   Y;            
-  short   X;            
-  uint16   BaseScaleY;  
-  uint16   BaseScaleX;  
-} uObjSubMtx;           
+typedef struct
+{
+  short    Y;
+  short    X;
+  uint16   BaseScaleY;
+  uint16   BaseScaleX;
+} uObjSubMtx;
 
-typedef struct  {       // Intel Format
-  uint16    imageW;     
-  uint16    imageX;     
 
-  uint16    frameW;     
-  short     frameX;     
+typedef struct // Intel Format
+{
+  uint16    imageW;     // Texture width
+  uint16    imageX;     // X-coordinate of the upper-left position of the texture.
 
-  uint16    imageH;     
-  uint16    imageY;     
+  uint16    frameW;     // Width of the frame to be transferred.
+  short     frameX;     // X-coordinate of the upper-left position of the frame to be transferred.
 
-  uint16    frameH;     
-  short     frameY;     
+  uint16    imageH;     // Texture height
+  uint16    imageY;     // Y-coordinate of the upper-left position of the texture.
 
-  uint32    imagePtr;   
+  uint16    frameH;     // Height of the frame to be transferred.
+  short     frameY;     // Y-coordinate of the upper-left position of the frame to be transferred.  
 
-  uint8     imageSiz;   
-  uint8     imageFmt;   
-  uint16    imageLoad;  
+  uint32    imagePtr;   // Texture address within the DRAM.
 
-  uint16    imageFlip;  
-  uint16    imagePal;   
+  uint8     imageSiz;   // Texel size
+  uint8     imageFmt;   // Texel format
+  uint16    imageLoad;  // Can either be S2DEX_BGLT_LOADBLOCK (0x0033) or #define S2DEX_BGLT_LOADTILE (0xfff4).
 
-  uint16    tmemH;      
-  uint16    tmemW;      
-  uint16    tmemLoadTH; 
-  uint16    tmemLoadSH; 
-  uint16    tmemSize;   
-  uint16    tmemSizeW;  
-} uObjBg;               
+  uint16    imageFlip;  // Inverts the image if 0x01 is set.
+  uint16    imagePal;   // Palette number
 
-typedef struct  {   // Intel Format
-  uint16    imageW;     
-  uint16    imageX;     
+  uint16    tmemH;
+  uint16    tmemW;
+  uint16    tmemLoadTH;
+  uint16    tmemLoadSH;
+  uint16    tmemSize;
+  uint16    tmemSizeW;
+} uObjBg;
 
-  uint16    frameW;     
-  short     frameX;     
+// Intel Format
+typedef struct
+{
+  uint16    imageW;     // Texture width
+  uint16    imageX;     // X-coordinate of the upper-left position of the texture.
 
-  uint16    imageH;     
-  uint16    imageY;     
+  uint16    frameW;     // Width of the frame to be transferred.
+  short     frameX;     // X-coordinate of the upper-left position of the frame to be transferred.
 
-  uint16    frameH;     
-  short     frameY;     
+  uint16    imageH;     // Texture height
+  uint16    imageY;     // Y-coordinate of the upper-left position of the texture.
 
-  uint32    imagePtr;   
+  uint16    frameH;     // Height of the frame to be transferred.
+  short     frameY;     // Y-coordinate of the upper-left position of the frame to be transferred.   
 
-  uint8     imageSiz;   
-  uint8     imageFmt;   
-  uint16    imageLoad;  
+  uint32    imagePtr;   // Texture address within the DRAM.
 
-  uint16    imageFlip;  
-  uint16    imagePal;   
+  uint8     imageSiz;   // Texel size
+  uint8     imageFmt;   // Texel format
+  uint16    imageLoad;  // Can either be S2DEX_BGLT_LOADBLOCK (0x0033) or #define S2DEX_BGLT_LOADTILE (0xfff4)
 
-  uint16    scaleH;     
-  uint16    scaleW;     
+  uint16    imageFlip;  // Inverts the image if 0x01 is set.
+  uint16    imagePal;   // Palette number
 
-  s32       imageYorig; 
+  uint16    scaleH;     // Y-axis scale factor
+  uint16    scaleW;     // X-axis scale factor
+
+  s32       imageYorig; // Starting point in the original image.
   uint8     padding[4];
 } uObjScaleBg;
 

--- a/gles2rice/src/TextureFilters.cpp
+++ b/gles2rice/src/TextureFilters.cpp
@@ -793,7 +793,7 @@ void EnhanceTexture(TxtrCacheEntry *pEntry)
 /************************************************************************/
 /*                                                                      */
 /************************************************************************/
-void MirrorEmulator_DrawLine(DrawInfo& destInfo, DrawInfo& srcInfo, uint32 *pSource, uint32 *pDest, uint32 nWidth, BOOL bFlipLeftRight)
+void MirrorEmulator_DrawLine(DrawInfo& destInfo, DrawInfo& srcInfo, uint32 *pSource, uint32 *pDest, uint32 nWidth, bool bFlipLeftRight)
 {
     if(!bFlipLeftRight)
     {
@@ -811,7 +811,7 @@ void MirrorEmulator_DrawLine(DrawInfo& destInfo, DrawInfo& srcInfo, uint32 *pSou
 }
 
 
-void MirrorEmulator_Draw(DrawInfo& destInfo, DrawInfo& srcInfo, uint32 nDestX, uint32 nDestY, BOOL bFlipLeftRight, BOOL bFlipUpDown)
+void MirrorEmulator_Draw(DrawInfo& destInfo, DrawInfo& srcInfo, uint32 nDestX, uint32 nDestY, bool bFlipLeftRight, bool bFlipUpDown)
 {
     uint8 *pDest = (uint8 *) destInfo.lpSurface + (destInfo.lPitch * nDestY) + (4 * nDestX);
     uint8 *pMaxDest = pDest + (destInfo.lPitch * srcInfo.dwHeight);
@@ -1000,15 +1000,15 @@ int GetImageInfoFromFile(char* pSrcFile, IMAGE_INFO *pSrcInfo)
     return 1;
 }
 
-BOOL PathFileExists(char* pszPath)
+bool PathFileExists(char* pszPath)
 {
     FILE *f = fopen(pszPath, "rb");
     if(f != NULL)
     {
         fclose(f);
-        return TRUE;
+        return true;
     }
-    return FALSE;
+    return false;
 }
 
 /********************************************************************************************************************


### PR DESCRIPTION
At least this gets rid of typedef'd unsigned ints in some places.

Also explicitly the constants within an enum in CombinerDefs.h. Makes for a quick reference when experimenting.
