### PR TITLE
default values if FE doesn't support core options (solves 0x0 viewport issue)

### DIFF
--- a/mupen64plus-core/src/api/config.c
+++ b/mupen64plus-core/src/api/config.c
@@ -1245,6 +1245,8 @@ EXPORT int CALL ConfigGetParamInt(m64p_handle ConfigSectionHandle, const char *P
         0
     };
 
+    int defaults[] = { 1, 0, 640, 480 };
+
     for (i = 0; libretro_translate[i].ParamName; i ++)
     {
         if (strcmp(ParamName, libretro_translate[i].ParamName) == 0)
@@ -1252,7 +1254,8 @@ EXPORT int CALL ConfigGetParamInt(m64p_handle ConfigSectionHandle, const char *P
             int result = choose_value(libretro_translate[i].RetroName, libretro_translate[i].Values);
             if (result >= 0)
                 return result;
-            break;
+            else
+		return defaults[i];
        }
     }
 


### PR DESCRIPTION
rarch behavior on _SET_VARIABLES is to return the same values upon future _GET_VARIABLE request (unless option has been changed). If this doesn't happen (FE without core options support) core will continue running using a scissor and a viewport of 0x0 with everything else working (including reporting 640x480 dimensions to video_cb).
