### PR TITLE
(Glitch64) negative polygonOffsetFactor seems to break some graphics

### DIFF
--- a/glide2gl/src/Glitch64/geometry.c
+++ b/glide2gl/src/Glitch64/geometry.c
@@ -299,7 +299,7 @@ void FindBestDepthBias(void)
    if (log_cb)
       log_cb(RETRO_LOG_INFO, "GL_RENDERER: %s\n", renderer);
 
-   polygonOffsetFactor = -3.0f;
+   polygonOffsetFactor = 0;
    polygonOffsetUnits  = -3.0f;
 
    biasFound = true;


### PR DESCRIPTION
This is about issue #65
