### PR TITLE
Dead zone compensation

### DIFF
--- a/libretro/input_plugin.c
+++ b/libretro/input_plugin.c
@@ -194,7 +194,7 @@ EXPORT void CALL inputControllerCommand(int Control, unsigned char *Command)
 
 // System analog stick range -0x8000 to 0x8000
 #define ASTICK_MAX 0x8000
-#define ASTICK_DEADZONE 0x2000
+#define ASTICK_DEADZONE 0x1000
 #define CSTICK_DEADZONE 0x4000
 
 #define CSTICK_RIGHT 0x200

--- a/libretro/input_plugin.c
+++ b/libretro/input_plugin.c
@@ -192,6 +192,8 @@ EXPORT void CALL inputControllerCommand(int Control, unsigned char *Command)
   output:   none
 *******************************************************************/
 
+// System analog stick range -0x8000 to 0x8000
+#define ASTICK_MAX 0x8000
 #define ASTICK_DEADZONE 0x2000
 #define CSTICK_DEADZONE 0x4000
 
@@ -219,7 +221,7 @@ static void inputGetKeys_reuse(int16_t analogX, int16_t analogY, int Control, BU
       // Rescale the analog stick range to negate the deadzone (makes slow movements possible)
       float val = ((analogX - sign * ASTICK_DEADZONE)*(ASTICK_MAX/(ASTICK_MAX - ASTICK_DEADZONE)));
       // Scale the analog stick value down to N64 range
-      val *= 80.0f / 32768.0f;
+      val *= 80.0f / ASTICK_MAX;
       Keys->X_AXIS = (int32_t)val;
    }
    else
@@ -229,7 +231,7 @@ static void inputGetKeys_reuse(int16_t analogX, int16_t analogY, int Control, BU
    {
       int sign = (analogY > 0) - (analogY < 0);
       float val = ((analogY - sign * ASTICK_DEADZONE)*(ASTICK_MAX/(ASTICK_MAX - ASTICK_DEADZONE)));
-      val *= 80.0f / 32768.0f;
+      val *= 80.0f / ASTICK_MAX;
       Keys->Y_AXIS = -(int32_t)val;
    }
    else

--- a/libretro/input_plugin.c
+++ b/libretro/input_plugin.c
@@ -215,16 +215,22 @@ static void inputGetKeys_reuse(int16_t analogX, int16_t analogY, int Control, BU
 
    if (abs(analogX) > ASTICK_DEADZONE)
    {
-      float val = 161.0f * ((analogX + 32768) / 65536.0f);
-      Keys->X_AXIS = ((int32_t)val) - 80;
+      int sign = (analogX > 0) - (analogX < 0);
+      // Rescale the analog stick range to negate the deadzone (makes slow movements possible)
+      float val = ((analogX - sign * ASTICK_DEADZONE)*(ASTICK_MAX/(ASTICK_MAX - ASTICK_DEADZONE)));
+      // Scale the analog stick value down to N64 range
+      val *= 80.0f / 32768.0f;
+      Keys->X_AXIS = (int32_t)val;
    }
    else
       Keys->X_AXIS = 0;
 
    if (abs(analogY) > ASTICK_DEADZONE)
    {
-      float val = 161.0f * ((analogY + 32768) / 65536.0f);
-      Keys->Y_AXIS = 0 - (((int32_t)val) - 80);
+      int sign = (analogY > 0) - (analogY < 0);
+      float val = ((analogY - sign * ASTICK_DEADZONE)*(ASTICK_MAX/(ASTICK_MAX - ASTICK_DEADZONE)));
+      val *= 80.0f / 32768.0f;
+      Keys->Y_AXIS = -(int32_t)val;
    }
    else
       Keys->Y_AXIS = 0;


### PR DESCRIPTION
This branch changes how the deadzone is handled. Before it was impossible to activate any range of the joystick that was inside the deadzone, which made it completely impossible to sneak in Banjo Tooie, or was slowly in any other game.

I also decreased the size of the deadzone (since the original 1/4th of the range felt like way too large of a deadzone) to 0x1000 which is 1/8th of the range (This should ideally be a Core Option in libretro though).
