### PR TITLE
Add deadzone adjustment to Core Options

### DIFF
--- a/libretro/input_plugin.c
+++ b/libretro/input_plugin.c
@@ -196,7 +196,6 @@ EXPORT void CALL inputControllerCommand(int Control, unsigned char *Command)
 
 // System analog stick range -0x8000 to 0x8000
 #define ASTICK_MAX 0x8000
-//#define ASTICK_DEADZONE 0x1000
 #define CSTICK_DEADZONE 0x4000
 
 #define CSTICK_RIGHT 0x200
@@ -220,7 +219,7 @@ static void inputGetKeys_reuse(int16_t analogX, int16_t analogY, int Control, BU
 
    if (abs(analogX) > astick_deadzone)
    {
-      float sign = (analogX > 0) - (analogX < 0);
+      int sign = (analogX > 0) - (analogX < 0);
       // Rescale the analog stick range to negate the deadzone (makes slow movements possible)
       float val = (analogX - sign * astick_deadzone)*((float)ASTICK_MAX/(ASTICK_MAX - astick_deadzone));
       // Scale the analog stick value down to N64 range

--- a/libretro/input_plugin.c
+++ b/libretro/input_plugin.c
@@ -196,7 +196,6 @@ EXPORT void CALL inputControllerCommand(int Control, unsigned char *Command)
 
 // System analog stick range -0x8000 to 0x8000
 #define ASTICK_MAX 0x8000
-//#define ASTICK_DEADZONE 0x1000
 #define CSTICK_DEADZONE 0x4000
 
 #define CSTICK_RIGHT 0x200


### PR DESCRIPTION
Also minor whtespace cleanup in a couple areas.

Mostly solves this issue:
https://github.com/libretro/mupen64plus-libretro/issues/87

The deadzones are still per-axis, not sure if this should be changed and/or made optional (it's rather annoying when you have a large deadzone).
