### PR TITLE
Fixing segfault when less than 4 controllers set on load

### DIFF
--- a/libretro/input_plugin.c
+++ b/libretro/input_plugin.c
@@ -32,6 +32,7 @@ extern retro_environment_t environ_cb;
 extern retro_input_state_t input_cb;
 extern struct retro_rumble_interface rumble;
 extern int pad_pak_types[4];
+extern int pad_present[4];
 extern uint16_t button_orientation;
 extern int astick_deadzone;
 
@@ -743,7 +744,7 @@ EXPORT void CALL inputInitiateControllers(CONTROL_INFO ControlInfo)
     for( i = 0; i < 4; i++ )
     {
        controller[i].control = ControlInfo.Controls + i;
-       controller[i].control->Present = 1;
+       controller[i].control->Present = pad_present[i];
        controller[i].control->RawData = 0;
        
        if (pad_pak_types[i] == PLUGIN_MEMPAK)

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -66,6 +66,7 @@ extern struct
 // ...but it won't be at least the first time we're called, in that case set
 // these instead for input_plugin to read.
 int pad_pak_types[4];
+int pad_present[4] = {1, 1, 1, 1};
 
 static void n64DebugCallback(void* aContext, int aLevel, const char* aMessage)
 {
@@ -753,17 +754,30 @@ bool retro_unserialize(const void * data, size_t size)
     return false;
 }
 
+//Needed to be able to detach controllers for Lylat Wars multiplayer
+//Only sets if controller struct is initialised as addon paks do.
 void retro_set_controller_port_device(unsigned in_port, unsigned device) {
     if (in_port < 4){
         switch(device)
         {
             case RETRO_DEVICE_NONE:
-                controller[in_port].control->Present = 0;
-                break;
+                if (controller[in_port].control){
+                    controller[in_port].control->Present = 0;
+                    break;
+                } else {
+                    pad_present[in_port] = 0;
+                    break;
+                }
+                
             case RETRO_DEVICE_JOYPAD:
             default:
-                controller[in_port].control->Present = 1;
-                break;
+                if (controller[in_port].control){
+                    controller[in_port].control->Present = 1;
+                    break;
+                } else {
+                    pad_present[in_port] = 1;
+                    break;
+                }
         }
     }
 }


### PR DESCRIPTION
Handles setting input status correctly when controller struct has not yet been initialised. Duplicated mechanism used for rumble and memory packs. This fixes the segfault on load and I believe correctly fixes issue #111
