### PR TITLE
fix segfault in wrong `pitchindwords' formula

### DIFF
--- a/angrylionrdp/n64video_main.c
+++ b/angrylionrdp/n64video_main.c
@@ -142,7 +142,7 @@ EXPORT int CALL angrylionRomOpen (void)
    screen_width = SCREEN_WIDTH;
    screen_height = SCREEN_HEIGHT;
    blitter_buf = (uint32_t*)calloc(screen_width * screen_height, sizeof(uint32_t));
-   pitchindwords = screen_width * 4;
+   pitchindwords = PRESCALE_WIDTH / 1; /* sizeof(DWORD) == sizeof(pixel) == 4 */
    screen_pitch = PRESCALE_WIDTH << 2;
 #else
     DDPIXELFORMAT ftpixel;


### PR DESCRIPTION
Currently the angrylionrdp (pixel-accurate) component of RetroArch core `mupen64plus-libretro` does not upload the RDRAM pixels for some reason (resulting in a black screen always).  While this issue is still unresolved, there also is a segfault getting in the way of testing for non-DirectDraw users.  When _not_ using DirectDraw (recommended for true pixel-accuracy), the screen pitch (note:  originally in Win32 DWORD units) formula was incorrectly defined as `screen_width * 4`.  This may have been my mistake from a previous commit of the original fork, but the size of one Win32 DWORD (that is, a 32-bit word) should be equal to the size of one RGBA pixel in 32-bit color mode, which is the optimal pixel transfer mode for the N64's 24-bit RGB DAC through something more advanced like OpenGL anyway.

The other problem was the use of the constant-ish (but still configurable) `screen_width`.  This was not necessarily equal to the memory allocated in the screen buffer array, which is exactly `PRESCALE_WIDTH * PRESCALE_HEIGHT` pixels, or `uint32_t` units.  Therefore, attempts to debug this code within libretro had frequently resulted in segfaults.

It is a temporary fix until the actual cause of the black screen issue is found.
