### PR TITLE
backporting some game fixes from upstream rsp repo

### DIFF
--- a/mupen64plus-rsp-cxd4/vu/vch.h
+++ b/mupen64plus-rsp-cxd4/vu/vch.h
@@ -15,30 +15,33 @@
 
 INLINE static void do_ch(short* VD, short* VS, short* VT)
 {
-    short eq[N], ge[N], le[N];
-    short sn[N];
-    short VC[N];
+    ALIGNED short VC[N];
+    ALIGNED short eq[N], ge[N], le[N];
+    ALIGNED short sn[N];
+#ifndef _DEBUG
     short diff[N];
+#endif
     register int i;
 
+    vector_copy(VC, VT);
     for (i = 0; i < N; i++)
-        VC[i] = VT[i];
+        sn[i] = VS[i] ^ VT[i];
     for (i = 0; i < N; i++)
-        sn[i] = (VS[i] ^ VC[i]) < 0;
+        sn[i] = (sn[i] < 0) ? ~0 :  0; /* signed SRA (sn), 15 */
     for (i = 0; i < N; i++)
-        VC[i] ^= -sn[i]; /* if (sn == ~0) {VT = ~VT;} else {VT =  VT;} */
+        VC[i] ^= sn[i]; /* if (sn == ~0) {VT = ~VT;} else {VT =  VT;} */
     for (i = 0; i < N; i++)
-        vce[i]  = (VS[i] == VC[i]); /* (VR[vs][i] + ~VC[i] == ~1); */
+        vce[i]  = (VS[i] == VC[i]); /* 2's complement:  VC = -VT - 1, or ~VT. */
     for (i = 0; i < N; i++)
         vce[i] &= sn[i];
     for (i = 0; i < N; i++)
-        VC[i] += sn[i]; /* converts ~(VT) into -(VT) if (sign) */
+        VC[i] -= sn[i]; /* converts ~(VT) into -(VT) if (sign) */
     for (i = 0; i < N; i++)
         eq[i]  = (VS[i] == VC[i]);
     for (i = 0; i < N; i++)
         eq[i] |= vce[i];
 
-#if (0)
+#ifdef _DEBUG
     for (i = 0; i < N; i++)
         le[i] = sn[i] ? (VS[i] <= VC[i]) : (VC[i] < 0);
     for (i = 0; i < N; i++)
@@ -50,27 +53,31 @@ INLINE static void do_ch(short* VD, short* VS, short* VT)
         ge[i] = sn[i] ? (~0x0000 >= VT[i]) : (VS[i] >= VT[i]);
 #else
     for (i = 0; i < N; i++)
-        diff[i] = -VS[i] | -(sn[i] ^ 1);
+        diff[i] = sn[i] | VS[i];
     for (i = 0; i < N; i++)
-        le[i] = VT[i] <= diff[i];
+        ge[i] = (diff[i] >= VT[i]);
+
     for (i = 0; i < N; i++)
-        diff[i] = +VS[i] | -(sn[i] ^ 0);
+        sn[i] = (unsigned short)(sn[i]) >> 15; /* ~0 to 1, 0 to 0 */
+
     for (i = 0; i < N; i++)
-        ge[i] = diff[i] >= VT[i];
+        diff[i] = VC[i] - VS[i];
+    for (i = 0; i < N; i++)
+        diff[i] = (diff[i] >= 0);
+    for (i = 0; i < N; i++)
+        le[i] = (VT[i] < 0);
+    merge(le, sn, diff, le);
 #endif
 
     merge(comp, sn, le, ge);
     merge(VACC_L, comp, VC, VS);
     vector_copy(VD, VACC_L);
 
-    for (i = 0; i < N; i++)
-        clip[i] = ge[i];
-    for (i = 0; i < N; i++)
-        comp[i] = le[i];
+    vector_copy(clip, ge);
+    vector_copy(comp, le);
     for (i = 0; i < N; i++)
         ne[i] = eq[i] ^ 1;
-    for (i = 0; i < N; i++)
-        co[i] = sn[i];
+    vector_copy(co, sn);
     return;
 }
 

--- a/mupen64plus-rsp-cxd4/vu/vcl.h
+++ b/mupen64plus-rsp-cxd4/vu/vcl.h
@@ -15,17 +15,15 @@
 
 INLINE static void do_cl(short* VD, short* VS, short* VT)
 {
-    short eq[N], ge[N], le[N];
-    short gen[N], len[N], lz[N], uz[N], sn[N];
+    ALIGNED unsigned short VB[N], VC[N];
+    ALIGNED short eq[N], ge[N], le[N];
+    ALIGNED short gen[N], len[N], lz[N], uz[N], sn[N];
     short diff[N];
     short cmp[N];
-    unsigned short VB[N], VC[N];
     register int i;
 
-    for (i = 0; i < N; i++)
-        VB[i] = VS[i];
-    for (i = 0; i < N; i++)
-        VC[i] = VT[i];
+    vector_copy((short *)VB, VS);
+    vector_copy((short *)VC, VT);
 
 /*
     for (i = 0; i < N; i++)
@@ -35,8 +33,8 @@ INLINE static void do_cl(short* VD, short* VS, short* VT)
 */
     for (i = 0; i < N; i++)
         eq[i] = ne[i] ^ 1;
-    for (i = 0; i < N; i++)
-        sn[i] = co[i];
+    vector_copy(sn, co);
+
 /*
  * Now that we have extracted all the flags, we will essentially be masking
  * them back in where they came from redundantly, unless the corresponding
@@ -49,7 +47,7 @@ INLINE static void do_cl(short* VD, short* VS, short* VT)
     for (i = 0; i < N; i++)
         diff[i] = VB[i] - VC[i];
     for (i = 0; i < N; i++)
-        uz[i] = (VB[i] - VC[i] - 0xFFFF) >> 31;
+        uz[i] = (VB[i] + (unsigned short)VT[i] - 65536) >> 31;
     for (i = 0; i < N; i++)
         lz[i] = (diff[i] == 0x0000);
     for (i = 0; i < N; i++)
@@ -77,10 +75,8 @@ INLINE static void do_cl(short* VD, short* VS, short* VT)
     merge(VACC_L, cmp, (short *)VC, VS);
     vector_copy(VD, VACC_L);
 
-    for (i = 0; i < N; i++)
-        clip[i] = ge[i];
-    for (i = 0; i < N; i++)
-        comp[i] = le[i];
+    vector_copy(clip, ge);
+    vector_copy(comp, le);
     for (i = 0; i < N; i++)
         ne[i] = 0;
     for (i = 0; i < N; i++)


### PR DESCRIPTION
Currently, the libretro Mupen64Plus core isn't in sync with the modern changes to the cxd4 RSP component, and I have not really finished optimizing parts of the RSP myself.  Now that the angrylion RDP is working, some bugs have been spotted in _Resident Evil 2_.  I have recognized these to be RSP interpreter issues--regressions from a year or two ago back when I was still experimenting early on with SIMD vectorization of the interpreter functions.  As a temporary fix until there is time to fully port the upstream cxd4 rsp to libretro, these commits should fix a few games--_Harvest Moon 64_, _Resident Evil 2_, _Wrestlemania 2000_, and some other weird game from hearsay that I can't remember the name of.
