### PR TITLE
should not have to make the user manually set HLE gfx option

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -521,18 +521,7 @@ void update_variables(bool startup)
    else
       overlay = 1;
 
-   var.key = "mupen64-cxd4-rsp-dl-to-video";
-   var.value = NULL;
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      if (!strcmp(var.value, "enabled"))
-         CFG_HLE_GFX = 1;
-      else if (!strcmp(var.value, "disabled"))
-         CFG_HLE_GFX = 0;
-   }
-   else
-      CFG_HLE_GFX = 1;
+   CFG_HLE_GFX = (gfx_plugin != GFX_ANGRYLION) ? 1 : 0;
 
    var.key = "mupen64-cxd4-rsp-al-to-audio";
    var.value = NULL;


### PR DESCRIPTION
Whether or not the RSP should process graphics command lists as LLE within the RSP interpreter itself, or to forward them to a HLE graphics plugin for external RSP simulation (e.g. Glide64, Rice, glN64 ...) should be easily detected based on what graphics plugin the libretro user is currently using.  There should be no reason to make the user change both the graphics plugin, and a second libretro setting on whether the RSP should assume the graphics plugin is LLE or HLE at the same time.
