### PR TITLE
Start to get build working on Microsoft Visual Studio again.

### DIFF
--- a/angrylionrdp/n64video_main.c
+++ b/angrylionrdp/n64video_main.c
@@ -80,10 +80,11 @@ EXPORT int CALL angrylionInitiateGFX (GFX_INFO Gfx_Info)
  
 EXPORT void CALL angrylionMoveScreen (int xpos, int ypos)
 {
+#ifdef HAVE_DIRECTDRAW
     RECT statusrect;
     POINT p;
+
     p.x = p.y = 0;
-#ifdef HAVE_DIRECTDRAW
     GetClientRect(gfx.hWnd, &__dst);
     ClientToScreen(gfx.hWnd, &p);
     OffsetRect(&__dst, p.x, p.y);

--- a/gles2n64/src/F3DCBFD.c
+++ b/gles2n64/src/F3DCBFD.c
@@ -66,9 +66,9 @@ void F3DCBFD_Vtx(u32 w0, u32 w1)
       gSPProcessVertex(v);
 
       nonblack = 0;
-      nonblack += OGL.triangles.vertices[v].r;
-      nonblack += OGL.triangles.vertices[v].g;
-      nonblack += OGL.triangles.vertices[v].b;
+      nonblack += (u32)OGL.triangles.vertices[v].r;
+      nonblack += (u32)OGL.triangles.vertices[v].g;
+      nonblack += (u32)OGL.triangles.vertices[v].b;
 
       if (config.enableLighting && (gSP.geometryMode & G_LIGHTING) && (nonblack != 0))
       {

--- a/gles2n64/src/F3DEX.c
+++ b/gles2n64/src/F3DEX.c
@@ -42,7 +42,7 @@ void F3DEX_Quad( u32 w0, u32 w1 )
 
 void F3DEX_Branch_Z( u32 w0, u32 w1 )
 {
-   gSPBranchLessZ( gDP.half_1, _SHIFTR( w0, 1, 11 ), (s32)w1 );
+   gSPBranchLessZ( gDP.half_1, _SHIFTR( w0, 1, 11 ), (f32)(s32)w1 );
 }
 
 void F3DEX_Load_uCode( u32 w0, u32 w1 )

--- a/gles2n64/src/ShaderCombiner.c
+++ b/gles2n64/src/ShaderCombiner.c
@@ -486,7 +486,7 @@ void _force_uniforms(void)
    SC_ForceUniform1f(uK5, gDP.convert.k5);
    SC_ForceUniform4fv(uFogColor, &gDP.fogColor.r);
    SC_ForceUniform1i(uEnableFog, ((config.enableFog==1) && (gSP.geometryMode & G_FOG)));
-   SC_ForceUniform1f(uRenderState, OGL.renderState);
+   SC_ForceUniform1f(uRenderState, (float) OGL.renderState);
    SC_ForceUniform1f(uFogMultiplier, (float) gSP.fog.multiplier / 255.0f);
    SC_ForceUniform1f(uFogOffset, (float) gSP.fog.offset / 255.0f);
    SC_ForceUniform1f(uAlphaRef, (gDP.otherMode.cvgXAlpha) ? 0.5 : gDP.blendColor.a);
@@ -536,7 +536,7 @@ void _update_uniforms(void)
    SC_SetUniform1f(uPrimLODFrac, gDP.primColor.l);
    SC_SetUniform4fv(uFogColor, &gDP.fogColor.r);
    SC_SetUniform1i(uEnableFog, (config.enableFog && (gSP.geometryMode & G_FOG)));
-   SC_SetUniform1f(uRenderState, OGL.renderState);
+   SC_SetUniform1f(uRenderState, (float) OGL.renderState);
    SC_SetUniform1f(uFogMultiplier, (float) gSP.fog.multiplier / 255.0f);
    SC_SetUniform1f(uFogOffset, (float) gSP.fog.offset / 255.0f);
    SC_SetUniform1f(uAlphaRef, (gDP.otherMode.cvgXAlpha) ? 0.5 : gDP.blendColor.a);

--- a/gles2n64/src/VI.c
+++ b/gles2n64/src/VI.c
@@ -33,8 +33,8 @@ void VI_UpdateSize(void)
       if (hEnd == hStart) hEnd = (u32)(*gfx_info.VI_WIDTH_REG / xScale);
 
 
-      VI.width = (hEnd - hStart) * xScale;
-      VI.height = (vEnd - vStart) * yScale * 1.0126582f;
+      VI.width = (u32)(xScale * (hEnd - hStart));
+      VI.height = (u32)(yScale * 1.0126582f * (vEnd - vStart));
    }
    else
    {
@@ -42,8 +42,8 @@ void VI_UpdateSize(void)
       VI.height = config.video.height;
    }
 
-   if (VI.width == 0.0f) VI.width = 320.0f;
-   if (VI.height == 0.0f) VI.height = 240.0f;
+   if (VI.width == 0.0f) VI.width = 320;
+   if (VI.height == 0.0f) VI.height = 240;
    VI.rwidth = 1.0f / VI.width;
    VI.rheight = 1.0f / VI.height;
 

--- a/gles2n64/src/gDP.c
+++ b/gles2n64/src/gDP.c
@@ -525,13 +525,15 @@ void gDPSetFillColor( u32 c )
 {
 
    gDP.fillColor.i = c;
-   gDP.fillColor.r = _SHIFTR( c, 11, 5 ) * 0.032258064f;
-   gDP.fillColor.g = _SHIFTR( c,  6, 5 ) * 0.032258064f;
-   gDP.fillColor.b = _SHIFTR( c,  1, 5 ) * 0.032258064f;
-   gDP.fillColor.a = _SHIFTR( c,  0, 1 );
+   gDP.fillColor.r = _SHIFTR( c, 11,  5 ) * 0.032258064f;
+   gDP.fillColor.g = _SHIFTR( c,  6,  5 ) * 0.032258064f;
+   gDP.fillColor.b = _SHIFTR( c,  1,  5 ) * 0.032258064f;
+   gDP.fillColor.a = _SHIFTR( c,  0,  1 ) * 1.0f;
 
-   gDP.fillColor.z = _SHIFTR( c,  2, 14 );
-   gDP.fillColor.dz = _SHIFTR( c, 0, 2 );
+   gDP.fillColor.z =
+                (f32)_SHIFTR( c,  2, 14 );
+   gDP.fillColor.dz =
+                (f32)_SHIFTR( c,  0,  2 );
 
 #ifdef DEBUG
    DebugMsg( DEBUG_HIGH | DEBUG_HANDLED, "gDPSetFillColor( 0x%08X );\n", c );

--- a/gles2n64/src/gDP.h
+++ b/gles2n64/src/gDP.h
@@ -269,9 +269,9 @@ void gDPSetBlendColor( u32 r, u32 g, u32 b, u32 a );
 void gDPSetFogColor( u32 r, u32 g, u32 b, u32 a );
 void gDPSetFillColor( u32 c );
 void gDPSetPrimColor( u32 m, u32 l, u32 r, u32 g, u32 b, u32 a );
-void gDPSetTile(u32 format, const u32 size, const u32 line, const u32 tmem, u32 tile,
-               const u32 palette, const u32 cmt, const u32 cms, const u32 maskt, const u32 masks,
-               const u32 shiftt, const u32 shifts );
+void gDPSetTile(
+    u32 format, u32 size, u32 line, u32 tmem, u32 tile, u32 palette, u32 cmt,
+    u32 cms, u32 maskt, u32 masks, u32 shiftt, u32 shifts );
 void gDPSetTileSize( u32 tile, u32 uls, u32 ult, u32 lrs, u32 lrt );
 void gDPLoadTile( u32 tile, u32 uls, u32 ult, u32 lrs, u32 lrt );
 void gDPLoadBlock( u32 tile, u32 uls, u32 ult, u32 lrs, u32 dxt );

--- a/gles2n64/src/gSP.c
+++ b/gles2n64/src/gSP.c
@@ -53,7 +53,7 @@ void gSPTriangle(s32 v0, s32 v1, s32 v2)
    gDP.colorImage.height = (unsigned int)(max( gDP.colorImage.height, gDP.scissor.lry ));
 }
 
-void gSP1Triangle( const s32 v0, const s32 v1, const s32 v2)
+void gSP1Triangle( s32 v0, s32 v1, s32 v2)
 {
    gSPTriangle( v0, v1, v2);
    gSPFlushTriangles();
@@ -1074,10 +1074,12 @@ void gSPInsertMatrix( u32 where, u32 num )
    if (where < 0x20)
    {
       fraction = modff( gSP.matrix.combined[0][where >> 1], &integer );
-      gSP.matrix.combined[0][where >> 1] = (s16)_SHIFTR( num, 16, 16 ) + abs( (int)fraction );
+      gSP.matrix.combined[0][where >> 1]
+       = (f32)_SHIFTR( num, 16, 16 ) + abs( (int)fraction );
 
       fraction = modff( gSP.matrix.combined[0][(where >> 1) + 1], &integer );
-      gSP.matrix.combined[0][(where >> 1) + 1] = (s16)_SHIFTR( num, 0, 16 ) + abs( (int)fraction );
+      gSP.matrix.combined[0][(where >> 1) + 1]
+       = (f32)_SHIFTR( num, 0, 16 ) + abs( (int)fraction );
    }
    else
    {
@@ -1223,23 +1225,23 @@ void gSPBgRect1Cyc( u32 bg )
 	   frameX0, frameX1, frameY0, frameY1, frameS0, frameT0;
    addr = RSP_SegmentToPhysical(bg) >> 1;
 
-   imageX	= (((uint16_t*)gfx_info.RDRAM)[(addr+0)^1] >> 5);	// 0
-   imageY	= (((uint16_t*)gfx_info.RDRAM)[(addr+4)^1] >> 5);	// 4
-   imageW	= (((uint16_t*)gfx_info.RDRAM)[(addr+1)^1] >> 2);	// 1
-   imageH	= (((uint16_t*)gfx_info.RDRAM)[(addr+5)^1] >> 2);	// 5
+   imageX = (f32)(((uint16_t*)gfx_info.RDRAM)[(addr+0)^1] >> 5); /* 0 */
+   imageY = (f32)(((uint16_t*)gfx_info.RDRAM)[(addr+4)^1] >> 5); /* 4 */
+   imageW = (f32)(((uint16_t*)gfx_info.RDRAM)[(addr+1)^1] >> 2); /* 1 */
+   imageH = (f32)(((uint16_t*)gfx_info.RDRAM)[(addr+5)^1] >> 2); /* 5 */
 
-   frameX	= ((int16_t*)gfx_info.RDRAM)[(addr+2)^1] / 4.0f;	// 2
-   frameY	= ((int16_t*)gfx_info.RDRAM)[(addr+6)^1] / 4.0f;	// 6
-   frameW	= ((uint16_t*)gfx_info.RDRAM)[(addr+3)^1] >> 2;		// 3
-   frameH	= ((uint16_t*)gfx_info.RDRAM)[(addr+7)^1] >> 2;		// 7
+   frameX = (f32)((int16_t*)gfx_info.RDRAM)[(addr+2)^1] / 4.0f;  /* 2 */
+   frameY = (f32)((int16_t*)gfx_info.RDRAM)[(addr+6)^1] / 4.0f;  /* 6 */
+   frameW = (f32)(((uint16_t*)gfx_info.RDRAM)[(addr+3)^1] >> 2); /* 3 */
+   frameH = (f32)(((uint16_t*)gfx_info.RDRAM)[(addr+7)^1] >> 2); /* 7 */
 
 
    imageFlip = ((uint16_t*)gfx_info.RDRAM)[(addr+13)^1];	// 13;
    //d.flipX 	= (uint8_t)imageFlip&0x01;
 
    gSP.bgImage.address	= RSP_SegmentToPhysical(((u32*)gfx_info.RDRAM)[(addr+8)>>1]);	// 8,9
-   gSP.bgImage.width = imageW;
-   gSP.bgImage.height = imageH;
+   gSP.bgImage.width = (u32)imageW;
+   gSP.bgImage.height = (u32)imageH;
    gSP.bgImage.format = ((u8*)gfx_info.RDRAM)[(((addr+11)<<1)+0)^3];
    gSP.bgImage.size = ((u8*)gfx_info.RDRAM)[(((addr+11)<<1)+1)^3];
    gSP.bgImage.palette = ((u16*)gfx_info.RDRAM)[(addr+12)^1];
@@ -1328,7 +1330,17 @@ void gSPBgRectCopy( u32 bg )
 
    gSPTexture( 1.0f, 1.0f, 0, 0, TRUE );
 
-   gDPTextureRectangle( frameX, frameY, frameX + frameW - 1, frameY + frameH - 1, 0, imageX, imageY, 4, 1 );
+   gDPTextureRectangle(
+      frameX,
+      frameY,
+      frameX + frameW - 1.f,
+      frameY + frameH - 1.f,
+      0,
+      imageX,
+      imageY,
+      4,
+      1
+   );
 }
 
 void gSPObjRectangle( u32 sp )
@@ -1405,20 +1417,20 @@ void gSPObjSprite( u32 sp )
    OGL.triangles.vertices[v1].y = gSP.objMatrix.C * x1 + gSP.objMatrix.D * y0 + gSP.objMatrix.Y;
    OGL.triangles.vertices[v1].z = 0.0f;
    OGL.triangles.vertices[v1].w = 1.0f;
-   OGL.triangles.vertices[v1].s = imageW - 1;
+   OGL.triangles.vertices[v1].s = imageW - 1.f;
    OGL.triangles.vertices[v1].t = 0.0f;
    OGL.triangles.vertices[v2].x = gSP.objMatrix.A * x1 + gSP.objMatrix.B * y1 + gSP.objMatrix.X;
    OGL.triangles.vertices[v2].y = gSP.objMatrix.C * x1 + gSP.objMatrix.D * y1 + gSP.objMatrix.Y;
    OGL.triangles.vertices[v2].z = 0.0f;
    OGL.triangles.vertices[v2].w = 1.0f;
-   OGL.triangles.vertices[v2].s = imageW - 1;
-   OGL.triangles.vertices[v2].t = imageH - 1;
+   OGL.triangles.vertices[v2].s = imageW - 1.f;
+   OGL.triangles.vertices[v2].t = imageH - 1.f;
    OGL.triangles.vertices[v3].x = gSP.objMatrix.A * x0 + gSP.objMatrix.B * y1 + gSP.objMatrix.X;
    OGL.triangles.vertices[v3].y = gSP.objMatrix.C * x0 + gSP.objMatrix.D * y1 + gSP.objMatrix.Y;
    OGL.triangles.vertices[v3].z = 0.0f;
    OGL.triangles.vertices[v3].w = 1.0f;
    OGL.triangles.vertices[v3].s = 0;
-   OGL.triangles.vertices[v3].t = imageH - 1;
+   OGL.triangles.vertices[v3].t = imageH - 1.f;
 
    gDPSetTile( objSprite->imageFmt, objSprite->imageSiz, objSprite->imageStride, objSprite->imageAdrs, 0, objSprite->imagePal, G_TX_CLAMP, G_TX_CLAMP, 0, 0, 0, 0 );
    gDPSetTileSize( 0, 0, 0, (imageW - 1) << 2, (imageH - 1) << 2 );

--- a/gles2n64/src/gSP.c
+++ b/gles2n64/src/gSP.c
@@ -331,9 +331,9 @@ static void gSPLightVertex_default(u32 v)
       g += gSP.lights[i].g * intensity;
       b += gSP.lights[i].b * intensity;
    }
-   OGL.triangles.vertices[v].r = min(1.0, r);
-   OGL.triangles.vertices[v].g = min(1.0, g);
-   OGL.triangles.vertices[v].b = min(1.0, b);
+   OGL.triangles.vertices[v].r = min(1.0f, r);
+   OGL.triangles.vertices[v].g = min(1.0f, g);
+   OGL.triangles.vertices[v].b = min(1.0f, b);
 }
 
 static void gSPBillboardVertex_default(u32 v, u32 i)

--- a/glide2gl/src/Glide64/Combine.c
+++ b/glide2gl/src/Glide64/Combine.c
@@ -386,14 +386,14 @@ COMBINE cmb;
   cmb.tmu1_func = GR_COMBINE_FUNCTION_LOCAL, \
   cmb.tmu0_func = GR_COMBINE_FUNCTION_SCALE_OTHER_ADD_LOCAL, \
   cmb.tmu0_fac = GR_COMBINE_FACTOR_DETAIL_FACTOR, \
-  percent = rdp.prim_color_sep[3], \
+  percent = (float)rdp.prim_color_sep[3], \
   cmb.dc0_detailmax = cmb.dc1_detailmax = percent
 #define T1_MUL_ENVA_ADD_T0() \
   cmb.tex |= 3, \
   cmb.tmu1_func = GR_COMBINE_FUNCTION_LOCAL, \
   cmb.tmu0_func = GR_COMBINE_FUNCTION_SCALE_OTHER_ADD_LOCAL, \
   cmb.tmu0_fac = GR_COMBINE_FACTOR_DETAIL_FACTOR, \
-  percent = rdp.env_color_sep[3], \
+  percent = (float)rdp.env_color_sep[3], \
   cmb.dc0_detailmax = cmb.dc1_detailmax = percent
 #define T0_SUB_PRIM_MUL_PRIMLOD_ADD_T1() \
   T0_ADD_T1(); \
@@ -532,14 +532,14 @@ COMBINE cmb;
   cmb.tmu1_a_func = GR_COMBINE_FUNCTION_LOCAL, \
   cmb.tmu0_a_func = GR_COMBINE_FUNCTION_SCALE_OTHER_ADD_LOCAL, \
   cmb.tmu0_a_fac = GR_COMBINE_FACTOR_DETAIL_FACTOR, \
-  percent = rdp.prim_color_sep[3], \
+  percent = (float)rdp.prim_color_sep[3], \
   cmb.dc0_detailmax = cmb.dc1_detailmax = percent
 #define A_T1_MUL_ENVA_ADD_T0() \
   cmb.tex |= 3, \
   cmb.tmu1_a_func = GR_COMBINE_FUNCTION_LOCAL, \
   cmb.tmu0_a_func = GR_COMBINE_FUNCTION_SCALE_OTHER_ADD_LOCAL, \
   cmb.tmu0_a_fac = GR_COMBINE_FACTOR_DETAIL_FACTOR, \
-  percent = rdp.env_color_sep[3], \
+  percent = (float)rdp.env_color_sep[3], \
   cmb.dc0_detailmax = cmb.dc1_detailmax = percent
 
 
@@ -1655,16 +1655,20 @@ static void cc__shade_inter_t0_using_shadea__mul_shade()
 
 static void cc__prim_inter_env_using_enva__mul_shade(void)
 {
-   const float ea = rdp.env_color_sep[3];
-   uint32_t r = (rdp.env_color_sep[0] * ea + rdp.prim_color_sep[0] * (1.0f - ea));
-   uint32_t g = (rdp.env_color_sep[1] * ea + rdp.prim_color_sep[1] * (1.0f - ea));
-   uint32_t b = (rdp.env_color_sep[2] * ea + rdp.prim_color_sep[2] * (1.0f - ea));
-   uint32_t rgb = (r << 24) | (g << 16) | (b << 8) | 0xFF;
+   uint32_t rgba[4];
+   const float ea = (float)rdp.env_color_sep[3];
+
+   rgba[0] = (uint32_t)
+      (rdp.env_color_sep[0] * ea + rdp.prim_color_sep[0] * (1.0f - ea));
+   rgba[1] = (uint32_t)
+      (rdp.env_color_sep[1] * ea + rdp.prim_color_sep[1] * (1.0f - ea));
+   rgba[2] = (uint32_t)
+      (rdp.env_color_sep[2] * ea + rdp.prim_color_sep[2] * (1.0f - ea));
    CCMB (GR_COMBINE_FUNCTION_SCALE_OTHER,
          GR_COMBINE_FACTOR_LOCAL,
          GR_COMBINE_LOCAL_ITERATED,
          GR_COMBINE_OTHER_CONSTANT);
-   cmb.ccolor= rgb & 0xFFFFFF00;
+   cmb.ccolor= (rgba[0] << 24) | (rgba[1] << 16) | (rgba[2] << 8);
 }
 
 //Added by Gonetz
@@ -1937,7 +1941,7 @@ static void cc_one_sub__one_sub_t0_mul_enva_add_prim__mul_prim(void) //Aded by G
          GR_CMBX_B, 0);
    cmb.tex_ccolor = rdp.prim_color;
    cmb.tex |= 1;
-   percent = rdp.env_color_sep[3];
+   percent = (float)rdp.env_color_sep[3];
    cmb.dc0_detailmax = cmb.dc1_detailmax = percent;
    CCMBEXT(GR_CMBX_ZERO, GR_FUNC_MODE_X,
          GR_CMBX_TEXTURE_RGB, GR_FUNC_MODE_NEGATIVE_X,
@@ -1952,17 +1956,16 @@ static void cc_t0_add_env_mul_k5(void)
 {
    float scale;
    uint8_t r, g, b;
-   uint32_t rgb;
+
    CCMB (GR_COMBINE_FUNCTION_SCALE_OTHER_ADD_LOCAL,
          GR_COMBINE_FACTOR_ONE,
          GR_COMBINE_LOCAL_CONSTANT,
          GR_COMBINE_OTHER_TEXTURE);
    scale = rdp.K5 / 255.0f;
-   r = rdp.env_color_sep[0] * scale;
-   g = rdp.env_color_sep[1] * scale;
-   b = rdp.env_color_sep[2] * scale;
-   rgb = (r << 24)|(g << 16)|(b << 8);
-   cmb.ccolor= rgb & 0xFFFFFF00;
+   r = (uint8_t)(rdp.env_color_sep[0] * scale);
+   g = (uint8_t)(rdp.env_color_sep[1] * scale);
+   b = (uint8_t)(rdp.env_color_sep[2] * scale);
+   cmb.ccolor= (r << 24) | (g << 16) | (b << 8);
    USE_T0();
 }
 
@@ -1997,7 +2000,7 @@ static void cc__t0_sub_env_mul_enva__add_prim_mul_shade()
          GR_CMBX_ZERO, 0);
    cmb.tex_ccolor = rdp.env_color;
    cmb.tex |= 1;
-   percent = rdp.env_color_sep[3];
+   percent = (float)rdp.env_color_sep[3];
    cmb.dc0_detailmax = cmb.dc1_detailmax = percent;
 
    CCMBEXT(GR_CMBX_ITRGB, GR_FUNC_MODE_X,
@@ -2147,7 +2150,7 @@ static void cc__t1_sub_prim_mul_enva_add_t0__mul_prim_add_env()
          GR_CMBX_ZERO, 0);
    cmb.tex_ccolor = rdp.prim_color;
    cmb.tex |= 3;
-   percent = rdp.env_color_sep[3];
+   percent = (float)rdp.env_color_sep[3];
    cmb.dc0_detailmax = cmb.dc1_detailmax = percent;
 }
 
@@ -2580,7 +2583,7 @@ static void cc__t0_mul_enva_add_t1__mul_shade_add_prim()
          GR_CMBX_DETAIL_FACTOR, 0,
          GR_CMBX_B, 0);
    cmb.tex |= 3;
-   percent = rdp.env_color_sep[3];
+   percent = (float)rdp.env_color_sep[3];
    cmb.dc0_detailmax = cmb.dc1_detailmax = percent;
 }
 
@@ -3928,7 +3931,7 @@ static void cc_t1_sub_k4_mul_prima_add_t0()
    cmb.tex |= 3;
    CC_BYTE (rdp.K4);
    cmb.tex_ccolor = cmb.ccolor;
-   percent = rdp.prim_color_sep[3];
+   percent = (float)rdp.prim_color_sep[3];
    cmb.dc0_detailmax = cmb.dc1_detailmax = percent;
    CCMBEXT(GR_CMBX_TEXTURE_ALPHA, GR_FUNC_MODE_X,
          GR_CMBX_TEXTURE_RGB, GR_FUNC_MODE_ZERO,
@@ -4059,7 +4062,7 @@ static void cc_t0_sub_env_mul_prima_add_env()  //Aded by Gonetz
          GR_CMBX_DETAIL_FACTOR, 0,
          GR_CMBX_B, 0);
    cmb.tex |= 1;
-   percent = rdp.prim_color_sep[3];
+   percent = (float)rdp.prim_color_sep[3];
    cmb.dc0_detailmax = cmb.dc1_detailmax = percent;
    CCMB (GR_COMBINE_FUNCTION_SCALE_OTHER,
          GR_COMBINE_FACTOR_ONE,
@@ -4872,7 +4875,7 @@ static void cc_prim_sub_env_mul__t0_sub_t0_mul_prima__add_env()
    cmb.tex |= 1;
    cmb.tmu0_func = GR_COMBINE_FUNCTION_BLEND_LOCAL;
    cmb.tmu0_fac = GR_COMBINE_FACTOR_DETAIL_FACTOR;
-   percent = rdp.prim_color_sep[3];
+   percent = (float)rdp.prim_color_sep[3];
    cmb.dc0_detailmax = cmb.dc1_detailmax = percent;
 }
 
@@ -4985,18 +4988,16 @@ static void cc__prim_sub_env_mul_t0_add_env__mul_primlod()
 {
    float factor;
    uint8_t r, g, b;
-   uint32_t rgb;
 
    CCMB (GR_COMBINE_FUNCTION_BLEND,
          GR_COMBINE_FACTOR_TEXTURE_RGB,
          GR_COMBINE_LOCAL_ITERATED,
          GR_COMBINE_OTHER_CONSTANT);
    factor = rdp.prim_lodfrac / 255.0f;
-   r = (uint8_t)rdp.prim_color_sep[0] * factor;
-   g = (uint8_t)rdp.prim_color_sep[1] * factor;
-   b = (uint8_t)rdp.prim_color_sep[2] * factor;
-   rgb = (r << 24) | (g << 16) | (b << 8);
-   cmb.ccolor= (rgb) & 0xFFFFFF00;
+   r = (uint8_t)((uint8_t)rdp.prim_color_sep[0] * factor);
+   g = (uint8_t)((uint8_t)rdp.prim_color_sep[1] * factor);
+   b = (uint8_t)((uint8_t)rdp.prim_color_sep[2] * factor);
+   cmb.ccolor = (r << 24) | (g << 16) | (b << 8);
    SETSHADE_ENV();
    MULSHADE_PRIMLOD();
    USE_T0();
@@ -5006,17 +5007,16 @@ static void cc__prim_sub_env_mul_t0_add_env__mul_k5()
 {
    float factor;
    uint8_t r, g, b;
-   uint32_t rgb;
+
    CCMB (GR_COMBINE_FUNCTION_BLEND,
          GR_COMBINE_FACTOR_TEXTURE_RGB,
          GR_COMBINE_LOCAL_ITERATED,
          GR_COMBINE_OTHER_CONSTANT);
    factor = rdp.K5 / 255.0f;
-   r = (uint8_t)rdp.prim_color_sep[0] * factor;
-   g = (uint8_t)rdp.prim_color_sep[1] * factor;
-   b = (uint8_t)rdp.prim_color_sep[2] * factor;
-   rgb = ((r << 24) | (g << 16) | (b << 8));
-   cmb.ccolor= (rgb) & 0xFFFFFF00;
+   r = (uint8_t)((uint8_t)rdp.prim_color_sep[0] * factor);
+   g = (uint8_t)((uint8_t)rdp.prim_color_sep[1] * factor);
+   b = (uint8_t)((uint8_t)rdp.prim_color_sep[2] * factor);
+   cmb.ccolor= (r << 24) | (g << 16) | (b << 8);
    SETSHADE_ENV();
    MULSHADE_K5();
    USE_T0();
@@ -5426,7 +5426,7 @@ static void cc_prim_sub_env_mul__t0_mul_enva_add_t1__add_env()
          GR_CMBX_DETAIL_FACTOR, 0,
          GR_CMBX_B, 0);
    cmb.tex |= 3;
-   percent = rdp.env_color_sep[3];
+   percent = (float)rdp.env_color_sep[3];
    cmb.dc0_detailmax = cmb.dc1_detailmax = percent;
 }
 
@@ -10018,7 +10018,7 @@ static void ac__t1_sub_one_mul_enva_add_t0__mul_shade()
             GR_CMBX_DETAIL_FACTOR, 0,
             GR_CMBX_LOCAL_TEXTURE_ALPHA, 0);
       cmb.tex_ccolor = (cmb.tex_ccolor&0xFFFFFF00) | 0xFF ;
-      percent = rdp.env_color_sep[3];
+      percent = (float)rdp.env_color_sep[3];
       cmb.dc0_detailmax = cmb.dc1_detailmax = percent;
       cmb.tex |= 3;
    }

--- a/glide2gl/src/Glide64/TexCache.c
+++ b/glide2gl/src/Glide64/TexCache.c
@@ -988,9 +988,13 @@ static void LoadTex(int id, int tmu)
             do
             {
                uint8_t a = (*col & 0x0001);
-               uint8_t r = (1-percent_r) * (((*col & 0xF800) >> 11)) + percent_r * cr0;
-               uint8_t g = (1-percent_g) * (((*col & 0x07C0) >> 6)) + percent_g * cg0;
-               uint8_t b = (1-percent_b) * (((*col & 0x003E) >> 1)) + percent_b * cb0;
+               uint8_t r = (uint8_t)
+                  ((1-percent_r) * (((*col & 0xF800) >> 11)) + percent_r * cr0);
+               uint8_t g = (uint8_t)
+                  ((1-percent_g) * (((*col & 0x07C0) >>  6)) + percent_g * cg0);
+               uint8_t b = (uint8_t)
+                  ((1-percent_b) * (((*col & 0x003E) >>  1)) + percent_b * cb0);
+
                *col++ = (uint16_t)(((uint16_t)(r >> 3) << 11) |
                      ((uint16_t)(g >> 3) << 6) |
                      ((uint16_t)(b >> 3) << 1) |
@@ -1030,9 +1034,9 @@ static void LoadTex(int id, int tmu)
                float percent_g = ((*col & 0x07C0) >> 6) / 31.0f;
                float percent_b = ((*col & 0x003E) >> 1) / 31.0f;
                uint8_t a = (*col & 0x0001);
-               uint8_t r = (1.0f-percent_r) * cr0 + percent_r * cr1;
-               uint8_t g = (1.0f-percent_g) * cg0 + percent_g * cg1;
-               uint8_t b = (1.0f-percent_b) * cb0 + percent_b * cb1;
+               uint8_t r = (uint8_t)((1.0f-percent_r) * cr0 + percent_r * cr1);
+               uint8_t g = (uint8_t)((1.0f-percent_g) * cg0 + percent_g * cg1);
+               uint8_t b = (uint8_t)((1.0f-percent_b) * cb0 + percent_b * cb1);
                *col++ = (uint16_t)(((uint16_t)(r >> 3) << 11) |
                      ((uint16_t)(g >> 3) << 6) |
                      ((uint16_t)(b >> 3) << 1) |
@@ -1108,9 +1112,9 @@ static void LoadTex(int id, int tmu)
             do
             {
                uint8_t a = (*col & 0x0001);
-               uint8_t r = percent_r * (((*col & 0xF800) >> 11)) + cr0;
-               uint8_t g = percent_g * (((*col & 0x07C0) >> 6)) + cg0;
-               uint8_t b = percent_b * (((*col & 0x003E) >> 1)) + cb0;
+               uint8_t r = (uint8_t)(percent_r * ((*col & 0xF800) >> 11)) + cr0;
+               uint8_t g = (uint8_t)(percent_g * ((*col & 0x07C0) >> 6)) + cg0;
+               uint8_t b = (uint8_t)(percent_b * ((*col & 0x003E) >> 1)) + cb0;
                *col++ = (uint16_t)(((uint16_t)(r >> 3) << 11) |
                      ((uint16_t)(g >> 3) << 6) |
                      ((uint16_t)(b >> 3) << 1) |
@@ -1135,9 +1139,12 @@ static void LoadTex(int id, int tmu)
             do
             {
                uint8_t a = (*col & 0x0001);
-               uint8_t r = percent_r * (((*col & 0xF800) >> 11)) + (1-percent_r) * cr0;
-               uint8_t g = percent_g * (((*col & 0x07C0) >> 6)) + (1-percent_g) * cg0;
-               uint8_t b = percent_b * (((*col & 0x003E) >> 1)) + (1-percent_b) * cb0;
+               uint8_t r = (uint8_t)
+                  (uint8_t)(percent_r * ((*col & 0xF800) >> 11) + (1-percent_r) * cr0);
+               uint8_t g =
+                  (uint8_t)(percent_g * ((*col & 0x07C0) >>  6) + (1-percent_g) * cg0);
+               uint8_t b =
+                  (uint8_t)(percent_b * ((*col & 0x003E) >>  1) + (1-percent_b) * cb0);
                *col++ = (uint16_t)(((uint16_t)(r >> 3) << 11) |
                      ((uint16_t)(g >> 3) << 6) |
                      ((uint16_t)(b >> 3) << 1) |
@@ -1146,9 +1153,9 @@ static void LoadTex(int id, int tmu)
             break;
          case TMOD_TEX_INTER_COL_USING_TEXA:
             {
-               uint8_t r = (((modcolor >> 24) & 0xFF) / 255.0f * 31.0f);
-               uint8_t g = (((modcolor >> 16) & 0xFF) / 255.0f * 31.0f);
-               uint8_t b = (((modcolor >> 8)  & 0xFF) / 255.0f * 31.0f);
+               uint8_t r = (uint8_t)(((modcolor >> 24) & 0xFF) / 255.f * 31.f);
+               uint8_t g = (uint8_t)(((modcolor >> 16) & 0xFF) / 255.f * 31.f);
+               uint8_t b = (uint8_t)(((modcolor >>  8) & 0xFF) / 255.f * 31.f);
                uint8_t a = (modcolor & 0xFF) ? 1 : 0;
                uint16_t col16 = ((r << 11)|(g << 6)|(b << 1) | a);
 
@@ -1427,9 +1434,12 @@ static void LoadTex(int id, int tmu)
 
                   do
                   {
-                     uint8_t r = ((1 - percent) * (((*dst) >> 8) & 0xF) + percent * cr0);
-                     uint8_t g = ((1 - percent) * (((*dst) >> 4) & 0xF) + percent * cg0);
-                     uint8_t b = ((1 - percent) * ((*dst) & 0xF) + percent * cb0);
+                     uint8_t r = (uint8_t)
+                        ((1 - percent) * (((*dst) >> 8) & 0xF) + percent * cr0);
+                     uint8_t g = (uint8_t)
+                        ((1 - percent) * (((*dst) >> 4) & 0xF) + percent * cg0);
+                     uint8_t b = (uint8_t)
+                        ((1 - percent) * ((*dst) & 0xF) + percent * cb0);
                      *(dst++) = (*dst & 0xF000) | (r << 8) | (g << 4) | b;
                   }while(--size);
                }
@@ -1442,9 +1452,12 @@ static void LoadTex(int id, int tmu)
 
                   do
                   {
-                     uint8_t r = ((1 - percent_r) * (((*dst) >> 8) & 0xF) + percent_r * cr0);
-                     uint8_t g = ((1 - percent_g) * (((*dst) >> 4) & 0xF) + percent_g * cg0);
-                     uint8_t b = ((1 - percent_b) * ((*dst) & 0xF) + percent_b * cb0);
+                     uint8_t r = (uint8_t)
+                        ((1 - percent_r) * (((*dst) >> 8) & 0xF) + percent_r * cr0);
+                     uint8_t g = (uint8_t)
+                        ((1 - percent_g) * (((*dst) >> 4) & 0xF) + percent_g * cg0);
+                     uint8_t b = (uint8_t)
+                        ((1 - percent_b) * ((*dst) & 0xF) + percent_b * cb0);
                      *(dst++) = (*dst & 0xF000) | (r << 8) | (g << 4) | b;
                   }while(--size);
                }
@@ -1482,9 +1495,12 @@ static void LoadTex(int id, int tmu)
                      do
                      {
                         float percent = ((*dst & 0xF000) >> 12) / 15.0f;
-                        uint8_t r = ((((1 - percent) * cr0 + percent * cr1) / 15.0f) * ((((*dst) & 0x0F00) >> 8) / 15.0f) * 15.0f);
-                        uint8_t g = ((((1 - percent) * cg0 + percent * cg1) / 15.0f) * ((((*dst) & 0x00F0) >> 4) / 15.0f) * 15.0f);
-                        uint8_t b = ((((1 - percent) * cb0 + percent * cb1) / 15.0f) * (((*dst) & 0x000F) / 15.0f) * 15.0f);
+                        uint8_t r = (uint8_t)
+                           ((((1 - percent) * cr0 + percent * cr1) / 15.0f) * ((((*dst) & 0x0F00) >> 8) / 15.0f) * 15.0f);
+                        uint8_t g = (uint8_t)
+                           ((((1 - percent) * cg0 + percent * cg1) / 15.0f) * ((((*dst) & 0x00F0) >> 4) / 15.0f) * 15.0f);
+                        uint8_t b = (uint8_t)
+                           ((((1 - percent) * cb0 + percent * cb1) / 15.0f) * (((*dst) & 0x000F) / 15.0f) * 15.0f);
                         *(dst++) = (*dst & 0xF000) | (r << 8) | (g << 4) | b;
                      }while(--size);
                   }
@@ -1493,9 +1509,9 @@ static void LoadTex(int id, int tmu)
                      do
                      {
                         float percent = ((*dst & 0xF000) >> 12) / 15.0f;
-                        uint8_t r = ((1 - percent) * cr0 + percent * cr1);
-                        uint8_t g = ((1 - percent) * cg0 + percent * cg1);
-                        uint8_t b = ((1 - percent) * cb0 + percent * cb1);
+                        uint8_t r = (uint8_t)((1 - percent)*cr0 + percent*cr1);
+                        uint8_t g = (uint8_t)((1 - percent)*cg0 + percent*cg1);
+                        uint8_t b = (uint8_t)((1 - percent)*cb0 + percent*cb1);
                         *(dst++) = (*dst & 0xF000) | (r << 8) | (g << 4) | b;
                      }while(--size);
                   }
@@ -1511,9 +1527,12 @@ static void LoadTex(int id, int tmu)
                         float percent_r = (((*dst) >> 8) & 0xF) / 15.0f;
                         float percent_g = (((*dst) >> 4) & 0xF) / 15.0f;
                         float percent_b = ((*dst) & 0xF) / 15.0f;
-                        uint8_t r = ((1.0f-percent_r) * cr0 + percent_r * (((*dst) & 0x0F00) >> 8));
-                        uint8_t g = ((1.0f-percent_g) * cg0 + percent_g * (((*dst) & 0x00F0) >> 4));
-                        uint8_t b = ((1.0f-percent_b) * cb0 + percent_b * ((*dst) & 0x000F));       
+                        uint8_t r = (uint8_t)
+                           ((1.0f-percent_r) * cr0 + percent_r * (((*dst) & 0x0F00) >> 8));
+                        uint8_t g = (uint8_t)
+                           ((1.0f-percent_g) * cg0 + percent_g * (((*dst) & 0x00F0) >> 4));
+                        uint8_t b = (uint8_t)
+                           ((1.0f-percent_b) * cb0 + percent_b * ((*dst) & 0x000F));
                         *(dst++) = (*dst & 0xF000) | (r << 8) | (g << 4) | b;
                      }while(--size);
                   }
@@ -1522,9 +1541,12 @@ static void LoadTex(int id, int tmu)
                      do
                      {
                         float percent = ((*dst & 0xF000) >> 12) / 15.0f;
-                        uint8_t r = ((1 - percent) * cr0 + percent * ((*dst & 0x0F00) >> 8));
-                        uint8_t g = ((1 - percent) * cg0 + percent * ((*dst & 0x00F0) >> 4));
-                        uint8_t b = ((1 - percent) * cb0 + percent * (*dst & 0x000F));
+                        uint8_t r = (uint8_t)
+                           ((1 - percent)*cr0 + percent*((*dst & 0x0F00) >> 8));
+                        uint8_t g = (uint8_t)
+                           ((1 - percent)*cg0 + percent*((*dst & 0x00F0) >> 4));
+                        uint8_t b = (uint8_t)
+                           ((1 - percent)*cb0 + percent*(*dst & 0x000F));
                         *(dst++) = (*dst & 0xF000) | (r << 8) | (g << 4) | b;
                      }while(--size);
                   }
@@ -1538,9 +1560,12 @@ static void LoadTex(int id, int tmu)
                      float percent_r = (((*dst) >> 8) & 0xF) / 15.0f;
                      float percent_g = (((*dst) >> 4) & 0xF) / 15.0f;
                      float percent_b = (*dst & 0xF) / 15.0f;
-                     uint8_t r = (((1.0f-percent_r) * cr0 + percent_r * cr1) * percent_a + cr2 * (1.0f-percent_a));
-                     uint8_t g = (((1.0f-percent_g) * cg0 + percent_g * cg1) * percent_a + cg2 * (1.0f-percent_a));
-                     uint8_t b = (((1.0f-percent_b) * cb0 + percent_b * cb1) * percent_a + cb2 * (1.0f-percent_a));
+                     uint8_t r = (uint8_t)
+                        (((1.0f-percent_r)*cr0 + percent_r*cr1)*percent_a + cr2*(1.0f-percent_a));
+                     uint8_t g = (uint8_t)
+                        (((1.0f-percent_g)*cg0 + percent_g*cg1)*percent_a + cg2*(1.0f-percent_a));
+                     uint8_t b = (uint8_t)
+                        (((1.0f-percent_b)*cb0 + percent_b*cb1)*percent_a + cb2*(1.0f-percent_a));
                      *(dst++) = (*dst & 0xF000) | (r << 8) | (g << 4) | b;
                   }while(--size);
                }
@@ -1638,9 +1663,12 @@ static void LoadTex(int id, int tmu)
 
                   do
                   {
-                     uint8_t r = (percent_r * (((*dst) >> 8) & 0xF) + (1 - percent_r) * cr0);
-                     uint8_t g = (percent_g * (((*dst) >> 4) & 0xF) + (1 - percent_g) * cg0);
-                     uint8_t b = (percent_b * ((*dst) & 0xF) + (1 - percent_b) * cb0);
+                     uint8_t r = (uint8_t)
+                        (percent_r * (((*dst) >> 8) & 0xF) + (1 - percent_r) * cr0);
+                     uint8_t g = (uint8_t)
+                        (percent_g * (((*dst) >> 4) & 0xF) + (1 - percent_g) * cg0);
+                     uint8_t b = (uint8_t)
+                        (percent_b * ((*dst) & 0xF) + (1 - percent_b) * cb0);
                      *(dst++) = ((((*dst) >> 12) & 0xF) << 12) | (r << 8) | (g << 4) | b;
                   }while(--size);
                }
@@ -1664,9 +1692,12 @@ static void LoadTex(int id, int tmu)
                   do
                   {
                      uint8_t noise = rand()%16;
-                     uint8_t r = ((1 - percent_r) * (((*dst) >> 8) & 0xF) + percent_r * noise);
-                     uint8_t g = ((1 - percent_g) * (((*dst) >> 4) & 0xF) + percent_g * noise);
-                     uint8_t b = ((1 - percent_b) * (*dst & 0xF) + percent_b * noise);
+                     uint8_t r = (uint8_t)
+                        ((1 - percent_r)*(((*dst) >> 8) & 0xF) + percent_r*noise);
+                     uint8_t g = (uint8_t)
+                        ((1 - percent_g)*(((*dst) >> 4) & 0xF) + percent_g*noise);
+                     uint8_t b = (uint8_t)
+                        ((1 - percent_b)*(*dst & 0xF) + percent_b*noise);
                      *(dst++) = (*dst & 0xF000) | (r << 8) | (g << 4) | b;
                   }while(--size);
                }
@@ -1675,9 +1706,12 @@ static void LoadTex(int id, int tmu)
                do
                {
                   float percent = ((*dst & 0xF000) >> 12) / 15.0f;
-                  uint8_t r = (percent * cr0 + (1 - percent) * ((*dst & 0x0F00) >> 8));
-                  uint8_t g = (percent * cg0 + (1 - percent) * ((*dst & 0x00F0) >> 4));
-                  uint8_t b = (percent * cb0 + (1 - percent) * (*dst & 0x000F));
+                  uint8_t r = (uint8_t)
+                     (percent*cr0 + (1 - percent)*((*dst & 0x0F00) >> 8));
+                  uint8_t g = (uint8_t)
+                     (percent*cg0 + (1 - percent)*((*dst & 0x00F0) >> 4));
+                  uint8_t b = (uint8_t)
+                     (percent*cb0 + (1 - percent)*(*dst & 0x000F));
                   *(dst++) = (*dst & 0xF000) | (r << 8) | (g << 4) | b;
                }while(--size);
                break;
@@ -1696,9 +1730,9 @@ static void LoadTex(int id, int tmu)
 
                   do
                   {
-                     uint8_t r = cr0 + percent * (float)(((*dst) >> 8) & 0xF);
-                     uint8_t g = cg0 + percent * (float)(((*dst) >> 4) & 0xF);
-                     uint8_t b = cb0 + percent * (float)(*dst & 0xF);
+                     uint8_t r = (uint8_t)(cr0 + percent*(((*dst) >> 8) & 0xF));
+                     uint8_t g = (uint8_t)(cg0 + percent*(((*dst) >> 4) & 0xF));
+                     uint8_t b = (uint8_t)(cb0 + percent*(((*dst) >> 0) & 0xF));
                      *(dst++) = (*dst & 0xF000) | (r << 8) | (g << 4) | b;
                   }while(--size);
                }

--- a/glide2gl/src/Glide64/glide64_util.c
+++ b/glide2gl/src/Glide64/glide64_util.c
@@ -75,11 +75,11 @@ typedef struct
 
 static INLINE void InterpolateColors(VERTEX *dest, float percent, VERTEX *first, VERTEX *second)
 {
-   dest->r = first->r + percent * (second->r - first->r);
-   dest->g = first->g + percent * (second->g - first->g);
-   dest->b = first->b + percent * (second->b - first->b);
-   dest->a = first->a + percent * (second->a - first->a);
-   dest->f = first->f + percent * (second->f - first->f);
+   dest->r = (uint8_t)(first->r + percent*(second->r - first->r));
+   dest->g = (uint8_t)(first->g + percent*(second->g - first->g));
+   dest->b = (uint8_t)(first->b + percent*(second->b - first->b));
+   dest->a = (uint8_t)(first->a + percent*(second->a - first->a));
+   dest->f = ( float )(first->f + percent*(second->f - first->f));
 }
 
 void apply_shade_mods (VERTEX *v)
@@ -228,11 +228,15 @@ static void InterpolateColors3(VERTEX *v1, VERTEX *v2, VERTEX *v3, VERTEX *out)
 
    w = 1.0/interp3p(v1->oow,v2->oow,v3->oow,s1,s2);
 
-   out->r = interp3p(v1->r*v1->oow,v2->r*v2->oow,v3->r*v3->oow,s1,s2)*w;
-   out->g = interp3p(v1->g*v1->oow,v2->g*v2->oow,v3->g*v3->oow,s1,s2)*w;
-   out->b = interp3p(v1->b*v1->oow,v2->b*v2->oow,v3->b*v3->oow,s1,s2)*w;
-   out->a = interp3p(v1->a*v1->oow,v2->a*v2->oow,v3->a*v3->oow,s1,s2)*w;
-   out->f = (float)(interp3p(v1->f*v1->oow,v2->f*v2->oow,v3->f*v3->oow,s1,s2)*w);
+   out->r = (uint8_t)
+      (w * interp3p(v1->r*v1->oow,v2->r*v2->oow,v3->r*v3->oow,s1,s2));
+   out->g = (uint8_t)
+      (w * interp3p(v1->g*v1->oow,v2->g*v2->oow,v3->g*v3->oow,s1,s2));
+   out->b = (uint8_t)
+      (w * interp3p(v1->b*v1->oow,v2->b*v2->oow,v3->b*v3->oow,s1,s2));
+   out->a = (uint8_t)
+      (w * interp3p(v1->a*v1->oow,v2->a*v2->oow,v3->a*v3->oow,s1,s2));
+   out->f = interp3p(v1->f*v1->oow,v2->f*v2->oow,v3->f*v3->oow,s1,s2) * w;
 }
 
 static void InterpolateColors2(VERTEX *va, VERTEX *vb, VERTEX *res, float percent)
@@ -243,16 +247,16 @@ static void InterpolateColors2(VERTEX *va, VERTEX *vb, VERTEX *res, float percen
    //   res->q = res->oow;
    ba = va->b * va->oow;
    bb = vb->b * vb->oow;
-   res->b = interp2p(ba, bb, percent) * w;
+   res->b = (uint8_t)(interp2p(ba, bb, percent) * w);
    ga = va->g * va->oow;
    gb = vb->g * vb->oow;
-   res->g = interp2p(ga, gb, percent) * w;
+   res->g = (uint8_t)(interp2p(ga, gb, percent) * w);
    ra = va->r * va->oow;
    rb = vb->r * vb->oow;
-   res->r = interp2p(ra, rb, percent) * w;
+   res->r = (uint8_t)(interp2p(ra, rb, percent) * w);
    aa = va->a * va->oow;
    ab = vb->a * vb->oow;
-   res->a = interp2p(aa, ab, percent) * w;
+   res->a = (uint8_t)(interp2p(aa, ab, percent) * w);
    fa = va->f * va->oow;
    fb = vb->f * vb->oow;
    res->f = interp2p(fa, fb, percent) * w;

--- a/glide2gl/src/Glide64/ucode00.h
+++ b/glide2gl/src/Glide64/ucode00.h
@@ -581,7 +581,7 @@ static void uc0_moveword(uint32_t w0, uint32_t w1)
       case 0x04:
          if (((w0 >> 8)&0xFFFF) == 0x04)
          {
-            rdp.clip_ratio = vi_integer_sqrt(w1);
+            rdp.clip_ratio = (float)vi_integer_sqrt(w1);
             rdp.update |= UPDATE_VIEWPORT;
          }
          //FRDP ("clip %08lx, %08lx\n", w0, w1);

--- a/glide2gl/src/Glide64/ucode02.h
+++ b/glide2gl/src/Glide64/ucode02.h
@@ -507,7 +507,7 @@ static void uc2_moveword(uint32_t w0, uint32_t w1)
       case 0x04:
          if (offset == 0x04)
          {
-            rdp.clip_ratio = vi_integer_sqrt(w1);
+            rdp.clip_ratio = (float)vi_integer_sqrt(w1);
             rdp.update |= UPDATE_VIEWPORT;
          }
          //FRDP ("mw_clip %08lx, %08lx\n", w0, w1);

--- a/glide2gl/src/Glide64/ucode05.h
+++ b/glide2gl/src/Glide64/ucode05.h
@@ -267,7 +267,7 @@ static void uc5_moveword(uint32_t w0, uint32_t w1)
       case G_MW_CLIP:
          if (((rdp.cmd0>>8)&0xFFFF) == 0x04)
          {
-            rdp.clip_ratio = vi_integer_sqrt(w1);
+            rdp.clip_ratio = (float)vi_integer_sqrt(w1);
             rdp.update |= UPDATE_VIEWPORT;
          }
          break;

--- a/glide2gl/src/Glide64/ucode08.h
+++ b/glide2gl/src/Glide64/ucode08.h
@@ -244,7 +244,7 @@ static void uc8_moveword(uint32_t w0, uint32_t w1)
       case G_MW_CLIP:
          if (offset == 0x04)
          {
-            rdp.clip_ratio = vi_integer_sqrt(w1);
+            rdp.clip_ratio = (float)vi_integer_sqrt(w1);
             rdp.update |= UPDATE_VIEWPORT;
          }
          break;

--- a/glide2gl/src/Glitch64/glitch64_combiner.c
+++ b/glide2gl/src/Glitch64/glitch64_combiner.c
@@ -430,9 +430,26 @@ void update_uniforms(shader_program_key prog)
    glUniform1i(prog.texture1_location, 1);
 
    v2 = 1.0f;
-   glUniform3f(prog.vertexOffset_location,(width/2),(height/2),v2);
-   glUniform4f(prog.textureSizes_location,tex_width[0], tex_height[0] , tex_width[1], tex_height[1]);
-   glUniform4f(prog.exactSizes_location,tex_exactWidth[0], tex_exactHeight[0], tex_exactWidth[1], tex_exactHeight[1]);
+   glUniform3f(
+      prog.vertexOffset_location,
+      (GLfloat)width / 2.f,
+      (GLfloat)height / 2.f,
+      v2
+   );
+   glUniform4f(
+      prog.textureSizes_location,
+      (float)tex_width[0],
+      (float)tex_height[0],
+      (float)tex_width[1],
+      (float)tex_height[1]
+   );
+   glUniform4f(
+      prog.exactSizes_location,
+      (float)tex_exactWidth[0],
+      (float)tex_exactHeight[0],
+      (float)tex_exactWidth[1],
+      (float)tex_exactHeight[1]
+   );
 
    v0 = fog_enabled != 2 ? 0.0f : 1.0f;
    v2 /= (fogEnd - fogStart);

--- a/glide2gl/src/Glitch64/glitchmain.c
+++ b/glide2gl/src/Glitch64/glitchmain.c
@@ -249,7 +249,9 @@ grLfbWriteRegion( GrBuffer_t dst_buffer,
    {
       for (j=0; j<src_height; j++)
          for (i=0; i<src_width; i++)
-            buf[j * src_width+i] = (frameBuffer[(src_height-j-1)*(src_stride/2)+i]/(65536.0f*(2.0f/zscale)))+1-zscale/2.0f;
+            buf[j*src_width + i] = (uint8_t)
+               ((frameBuffer[(src_height-j-1)*(src_stride/2)+i]/(65536.0f*(2.0f/zscale)))+1-zscale/2.0f)
+            ;
 
       glEnable(GL_DEPTH_TEST);
       glDepthFunc(GL_ALWAYS);
@@ -291,22 +293,22 @@ grLfbWriteRegion( GrBuffer_t dst_buffer,
       tex_height = src_height;
       invert = 1;
 
-      data[0]   =     ((int)dst_x);                             //X 0
-      data[1]   =     invert*-((int)dst_y);                     //Y 0 
-      data[2]   =     0.0f;                                     //U 0 
-      data[3]   =     0.0f;                                     //V 0
-      data[4]   =     ((int)dst_x);                             //X 1
-      data[5]   =     invert*-((int)dst_y + (int)src_height);   //Y 1
-      data[6]   =     0.0f;                                     //U 1
-      data[7]   =     (float)src_height;                        //V 1
-      data[8]   =     ((int)dst_x + (int)src_width);
-      data[9]  =     invert*-((int)dst_y + (int)src_height);
-      data[10]  =     (float)src_width;
-      data[11]  =     (float)src_height;
-      data[12]  =     ((int)dst_x);
-      data[13]  =     invert*-((int)dst_y);
-      data[14]  =     0.0f;
-      data[15]  =     0.0f;
+      data[ 0] = (float)((int)dst_x);                             /* X 0 */
+      data[ 1] = (float)(invert*-((int)dst_y));                   /* Y 0 */
+      data[ 2] = 0.0f;                                            /* U 0 */
+      data[ 3] = 0.0f;                                            /* V 0 */
+      data[ 4] = (float)((int)dst_x);                             /* X 1 */
+      data[ 5] = (float)(invert*-((int)dst_y + (int)src_height)); /* Y 1 */
+      data[ 6] = 0.0f;                                            /* U 1 */
+      data[ 7] = (float)src_height;                               /* V 1 */
+      data[ 8] = (float)((int)dst_x + (int)src_width);
+      data[ 9] = (float)(invert*-((int)dst_y + (int)src_height));
+      data[10] = (float)src_width;
+      data[11] = (float)src_height;
+      data[12] = (float)((int)dst_x);
+      data[13] = (float)(invert*-((int)dst_y));
+      data[14] = 0.0f;
+      data[15] = 0.0f;
 
 #ifdef EMSCRIPTEN
       glBindBuffer(GL_ARRAY_BUFFER, glitch_vbo);

--- a/mupen64plus-core/src/api/config.c
+++ b/mupen64plus-core/src/api/config.c
@@ -1241,15 +1241,6 @@ EXPORT int CALL ConfigGetParamInt(m64p_handle ConfigSectionHandle, const char *P
    int i;
     config_section *section;
     config_var *var;
-
-#ifdef __LIBRETRO__
-    if (!strcmp(ParamName, "AnisoFilter"))
-#ifdef GLES
-       return 0;
-#else
-       return 1;
-#endif
-
     static const struct
     {
         const char* ParamName;
@@ -1312,6 +1303,14 @@ EXPORT int CALL ConfigGetParamInt(m64p_handle ConfigSectionHandle, const char *P
         },
         { 0, 0, { {0, 0} } }
     };
+
+#ifdef __LIBRETRO__
+    if (!strcmp(ParamName, "AnisoFilter"))
+#ifdef GLES
+       return 0;
+#else
+       return 1;
+#endif
 
     for (i = 0; libretro_translate[i].ParamName; i ++)
     {

--- a/mupen64plus-core/src/r4300/interpreter_tlb.def
+++ b/mupen64plus-core/src/r4300/interpreter_tlb.def
@@ -48,7 +48,7 @@ static void TLBWrite(unsigned int idx)
                invalid_code[i] = 1;
             if (!invalid_code[i])
             {
-                blocks[i]->adler32 = adler32(0, (const unsigned char *)&rdram[(tlb_LUT_r[i]&0x7FF000)/4], 0x1000);
+                blocks[i]->adler32 = adler32(0, (unsigned char *)&rdram[(tlb_LUT_r[i]&0x7FF000)/4], 0x1000);
                 
                 invalid_code[i] = 1;
             }
@@ -67,7 +67,7 @@ static void TLBWrite(unsigned int idx)
                invalid_code[i] = 1;
             if (!invalid_code[i])
             {
-               blocks[i]->adler32 = adler32(0, (const unsigned char *)&rdram[(tlb_LUT_r[i]&0x7FF000)/4], 0x1000);
+               blocks[i]->adler32 = adler32(0, (unsigned char *)&rdram[(tlb_LUT_r[i]&0x7FF000)/4], 0x1000);
                 
                invalid_code[i] = 1;
             }
@@ -117,7 +117,7 @@ static void TLBWrite(unsigned int idx)
          {
                if(blocks[i] && blocks[i]->adler32)
                {
-                  if(blocks[i]->adler32 == adler32(0,(const unsigned char *)&rdram[(tlb_LUT_r[i]&0x7FF000)/4],0x1000))
+                  if(blocks[i]->adler32 == adler32(0,(unsigned char *)&rdram[(tlb_LUT_r[i]&0x7FF000)/4],0x1000))
                      invalid_code[i] = 0;
                }
          }
@@ -129,7 +129,7 @@ static void TLBWrite(unsigned int idx)
          {
             if(blocks[i] && blocks[i]->adler32)
             {
-               if(blocks[i]->adler32 == adler32(0,(const unsigned char *)&rdram[(tlb_LUT_r[i]&0x7FF000)/4],0x1000))
+               if(blocks[i]->adler32 == adler32(0,(unsigned char *)&rdram[(tlb_LUT_r[i]&0x7FF000)/4],0x1000))
                   invalid_code[i] = 0;
             }
          }

--- a/mupen64plus-rsp-cxd4/config.h
+++ b/mupen64plus-rsp-cxd4/config.h
@@ -16,13 +16,6 @@
 
 extern unsigned char conf[32];
 
-#define _CRT_SECURE_NO_WARNINGS
-/*
- * This is only here for people using modern Microsoft compilers.
- * Usually the default warning level complains over "deprecated" CRT methods.
- * It's basically Microsoft's way of saying they're better than everyone.
- */
-
 #define MINIMUM_MESSAGE_PRIORITY    1
 #define EXTERN_COMMAND_LIST_GBI
 #define EXTERN_COMMAND_LIST_ABI

--- a/mupen64plus-rsp-cxd4/execute.h
+++ b/mupen64plus-rsp-cxd4/execute.h
@@ -345,7 +345,8 @@ EX:
                         *(int32_t *)(RSP.DMEM + addr) = SR[rt];
                     CONTINUE
                 case 062: /* LWC2 */
-                    offset = SE(inst, 6);
+                    offset = (signed)inst;
+                    offset = SE(offset, 6);
                     switch (rd)
                     {
                         case 000: /* LBV */
@@ -387,7 +388,8 @@ EX:
                     }
                     CONTINUE
                 case 072: /* SWC2 */
-                    offset = SE(inst, 6);
+                    offset = (signed)inst;
+                    offset = SE(offset, 6);
                     switch (rd)
                     {
                         case 000: /* SBV */

--- a/mupen64plus-rsp-cxd4/su.h
+++ b/mupen64plus-rsp-cxd4/su.h
@@ -1310,12 +1310,12 @@ INLINE static void SQV(int vt, int element, int offset, int base)
 {
     register uint32_t addr;
     register int b;
-    const int e = element;
+    const unsigned int e = element;
 
     addr = (SR[base] + 16*offset) & 0x00000FFF;
     if (e != 0x0)
     { /* happens with "Mia Hamm Soccer 64" */
-        register int i;
+        register unsigned int i;
 
         for (i = 0; i < 16 - addr%16; i++)
             RSP.DMEM[BES((addr + i) & 0xFFF)] = VR_B(vt, (e + i) & 0xF);


### PR DESCRIPTION
I've fixed a problem MSVC 2010 had in `mupen64plus-core/src/api/config.c` with a colossal mid-scope structure declaration and static definition--something not possible to compile with MSVC's minimalist-to-nonexistent C99 support.  Everything else in this PR is just subtle warning fixes (well, sort of...tried not to get overzealous with a few stylistic changes).

Probably over 150 warnings were fixed--mostly stuff like the infamous "loss of precision" warning you get with implicit type conversions.  Since I'm more of a believer in bending the code over to adjust to the compiler, as opposed to the other way around, I felt pretty inclined to fix them all.  They get in the way of analyzing the error report for why it still does not compile--in the best case scenario, leaving all these warnings there just meant having to scroll through pages of irrelevant crap every time I try to compile and look for the relevant errors.

Note that not all of the warnings are fixed (duh).  I only fixed the populous ones that flooded the output console, or the ones relevant to the presently outdated cxd4/angrylion code I'm partly responsible for.  All the MSVC level 1 and 2 (/W1 and /W2) warnings should be fixed, except for a couple /W2 ones in libretro.c related to the OpenGL context or whatever.  (I have no knowledge of that stuff.)  I fixed a few /W3 ones here and there I felt pretty sure about, but left almost all of the "unused variable" warnings in stuff like Glide64, because, I don't know whether those variables WERE at one time used but no longer are due to refactoring done by twinaphex and others possibly, so in the absence of knowing why exactly they're all unused I didn't feel responsible to fix those.
