### PR TITLE
more cleanups and some fixes for the Visual Studio build

### DIFF
--- a/gles2n64/src/OpenGL.c
+++ b/gles2n64/src/OpenGL.c
@@ -647,12 +647,12 @@ void OGL_DrawRect( int ulx, int uly, int lrx, int lry, float *color)
    glDisable(GL_SCISSOR_TEST);
    glDisable(GL_CULL_FACE);
 
-   OGL.rect[0].x = (float) ulx * (2.0f * VI.rwidth) - 1.0;
-   OGL.rect[0].y = (float) uly * (-2.0f * VI.rheight) + 1.0;
-   OGL.rect[1].x = (float) (lrx+1) * (2.0f * VI.rwidth) - 1.0;
+   OGL.rect[0].x = (float)ulx * (2.0f * VI.rwidth) - 1.0f;
+   OGL.rect[0].y = (float)uly * (-2.0f * VI.rheight) + 1.0f;
+   OGL.rect[1].x = (float)(lrx+1) * (2.0f * VI.rwidth) - 1.0f;
    OGL.rect[1].y = OGL.rect[0].y;
    OGL.rect[2].x = OGL.rect[0].x;
-   OGL.rect[2].y = (float) (lry+1) * (-2.0f * VI.rheight) + 1.0;
+   OGL.rect[2].y = (float)(lry+1) * (-2.0f * VI.rheight) + 1.0f;
    OGL.rect[3].x = OGL.rect[1].x;
    OGL.rect[3].y = OGL.rect[2].y;
 

--- a/gles2n64/src/ShaderCombiner.c
+++ b/gles2n64/src/ShaderCombiner.c
@@ -489,7 +489,7 @@ void _force_uniforms(void)
    SC_ForceUniform1f(uRenderState, (float) OGL.renderState);
    SC_ForceUniform1f(uFogMultiplier, (float) gSP.fog.multiplier / 255.0f);
    SC_ForceUniform1f(uFogOffset, (float) gSP.fog.offset / 255.0f);
-   SC_ForceUniform1f(uAlphaRef, (gDP.otherMode.cvgXAlpha) ? 0.5 : gDP.blendColor.a);
+   SC_ForceUniform1f(uAlphaRef, (gDP.otherMode.cvgXAlpha) ? 0.5f : gDP.blendColor.a);
    SC_ForceUniform2f(uTexScale, gSP.texture.scales, gSP.texture.scalet);
 
    if (gSP.textureTile[0])
@@ -539,7 +539,7 @@ void _update_uniforms(void)
    SC_SetUniform1f(uRenderState, (float) OGL.renderState);
    SC_SetUniform1f(uFogMultiplier, (float) gSP.fog.multiplier / 255.0f);
    SC_SetUniform1f(uFogOffset, (float) gSP.fog.offset / 255.0f);
-   SC_SetUniform1f(uAlphaRef, (gDP.otherMode.cvgXAlpha) ? 0.5 : gDP.blendColor.a);
+   SC_SetUniform1f(uAlphaRef, (gDP.otherMode.cvgXAlpha) ? 0.5f : gDP.blendColor.a);
    SC_SetUniform1f(uK4, gDP.convert.k4);
    SC_SetUniform1f(uK5, gDP.convert.k5);
 

--- a/gles2n64/src/Textures.c
+++ b/gles2n64/src/Textures.c
@@ -369,7 +369,7 @@ void TextureCache_Init(void)
    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
    glGenTextures( 32, cache.glNoiseNames );
 
-   srand(time(NULL));
+   srand((unsigned)time(NULL));
    for (i = 0; i < 32; i++)
    {
       glBindTexture( GL_TEXTURE_2D, cache.glNoiseNames[i] );

--- a/gles2n64/src/VI.c
+++ b/gles2n64/src/VI.c
@@ -51,8 +51,9 @@ void VI_UpdateSize(void)
    //add display buffer if doesn't exist
    if (config.ignoreOffscreenRendering)
    {
-      int i;
+      unsigned int i;
       //int start = *REG.VI_ORIGIN;
+
       u32 start = RSP_SegmentToPhysical(*gfx_info.VI_ORIGIN_REG) & 0x00FFFFFF;
       u32 end = min(start + VI.width * VI.height * 4, RDRAMSize);
       for(i = 0; i < VI.displayNum; i++)

--- a/gles2n64/src/gSP.c
+++ b/gles2n64/src/gSP.c
@@ -591,7 +591,11 @@ void gSPLookAt( u32 l )
 
 void gSPVertex( u32 v, u32 n, u32 v0 )
 {
-   int i, j;
+#ifdef __VEC4_OPT
+   unsigned int i, j;
+#else
+   unsigned int i;
+#endif
    Vertex *vertex;
    //flush batched triangles:
 
@@ -671,7 +675,7 @@ void gSPVertex( u32 v, u32 n, u32 v0 )
 
 void gSPCIVertex( u32 v, u32 n, u32 v0 )
 {
-   int i, j;
+   unsigned int i;
    PDVertex *vertex;
 
    u32 address = RSP_SegmentToPhysical( v );
@@ -755,7 +759,11 @@ void gSPCIVertex( u32 v, u32 n, u32 v0 )
 
 void gSPDMAVertex( u32 v, u32 n, u32 v0 )
 {
-   int i, j;
+#ifdef __VEC4_OPT
+   unsigned int i, j;
+#else
+   unsigned int i;
+#endif
    u32 address = gSP.DMAOffsets.vtx + RSP_SegmentToPhysical( v );
 
    if ((address + 10 * n) > RDRAMSize)
@@ -763,7 +771,7 @@ void gSPDMAVertex( u32 v, u32 n, u32 v0 )
 
    if ((n + v0) <= INDEXMAP_SIZE)
    {
-      u32 i = v0;
+      i = v0;
 #ifdef __VEC4_OPT
       for (; i < n - (n%4) + v0; i += 4)
       {
@@ -940,7 +948,7 @@ void gSPInterpolateVertex( SPVertex *dest, f32 percent, SPVertex *first, SPVerte
 
 void gSPDMATriangles( u32 tris, u32 n )
 {
-   int i, j;
+   unsigned int i;
    s32 v0, v1, v2;
    DKRTriangle *triangles;
    u32 address = RSP_SegmentToPhysical( tris );
@@ -994,20 +1002,19 @@ void gSP1Quadrangle( s32 v0, s32 v1, s32 v2, s32 v3)
 
 bool gSPCullVertices( u32 v0, u32 vn )
 {
-   int i, j;
-   s32 v;
+   unsigned int i;
+   u32 v;
    u32 clip;
 
    if (!config.enableClipping)
       return FALSE;
 
    v = v0;
-
    clip = OGL.triangles.vertices[v].clip;
    if (clip == 0)
       return FALSE;
 
-   for (i = (v0+1); i <= vn; i++)
+   for (i = v0 + 1; i <= vn; i++)
    {
       v = i;
       if (OGL.triangles.vertices[v].clip != clip) return FALSE;

--- a/gles2rice/src/DecodedMux.cpp
+++ b/gles2rice/src/DecodedMux.cpp
@@ -708,8 +708,8 @@ void DecodedMux::Reformat(bool do_complement)
         m_n64Combiners[3].d = MUX_COMBINED;
     }
     
-    unsigned cond3 = max(splitType[0], splitType[1]);
-    unsigned cond2 = max(cond3,splitType[2]);
+    signed cond3 = max(splitType[0], splitType[1]);
+    signed cond2 = max(cond3, splitType[2]);
     mType = (CombinerFormatType)max(cond2,splitType[3]);
 }
 

--- a/gles2rice/src/FrameBuffer.cpp
+++ b/gles2rice/src/FrameBuffer.cpp
@@ -1961,10 +1961,11 @@ void FrameBufferManager::CopyBufferToRDRAM(uint32_t addr, uint32_t fmt, uint32_t
                 for (uint32_t j=0; j<width; j++)
                 {
                     int pos = 4*(j*bufWidth/width);
-                    uint16_t tempword = ConvertRGBATo555((pS[pos+2]),   // Red
-                                                       (pS[pos+1]),   // Green
-                                                       (pS[pos+0]),   // Blue
-                                                       (pS[pos+3]));  // Alpha
+
+                    tempword = ConvertRGBATo555((pS[pos+2]),    /* Red */
+                                                (pS[pos+1]),    /* Green */
+                                                (pS[pos+0]),    /* Blue */
+                                                (pS[pos+3]));   /* Alpha */
 
                     //*pD = CIFindIndex(tempword);
                     *(pD+(j^3)) = RevTlutTable[tempword];

--- a/gles2rice/src/OGLDecodedMux.cpp
+++ b/gles2rice/src/OGLDecodedMux.cpp
@@ -31,9 +31,9 @@ void COGLDecodedMux::Simplify(void)
 void COGLDecodedMux::Reformat(void)
 {
     DecodedMux::Reformat(true);
-    unsigned cond3 = max(splitType[0], splitType[1]);
-    unsigned cond2 = max(cond3,splitType[2]);
-    mType = (CombinerFormatType)max(cond2,splitType[3]);
+    signed cond3 = max(splitType[0], splitType[1]);
+    signed cond2 = max(cond3, splitType[2]);
+    mType = (CombinerFormatType)max(cond2, splitType[3]);
 }
 
 void COGLExtDecodedMux::Simplify(void)

--- a/gles2rice/src/OGLES2FragmentShaders.cpp
+++ b/gles2rice/src/OGLES2FragmentShaders.cpp
@@ -698,9 +698,10 @@ void COGL_FragmentProgramCombiner::GenerateCombinerSettingConstants(int index)
     {
         // avoid slow float compare..
         if( *(int *)&gRDP.LODFrac != *(int *)&prog.EnvLODFrac ) {
-            prog.EnvLODFrac = gRDP.LODFrac;
             float frac = gRDP.LODFrac / 255.0f;
             float tempf[4] = {frac,frac,frac,frac};
+
+            prog.EnvLODFrac = (float)gRDP.LODFrac;
             glUniform4fv(prog.EnvFracLocation, 1, tempf);
             OPENGL_CHECK_ERRORS;
         }
@@ -709,9 +710,10 @@ void COGL_FragmentProgramCombiner::GenerateCombinerSettingConstants(int index)
     if(prog.PrimFracLocation != -1)
     {
         if( *(int *)&gRDP.primLODFrac != *(int *)&prog.PrimLODFrac ) {
-            prog.PrimLODFrac = gRDP.primLODFrac;
             float frac2 = gRDP.primLODFrac / 255.0f;
             float tempf2[4] = {frac2,frac2,frac2,frac2};
+
+            prog.PrimLODFrac = (float)gRDP.primLODFrac;
             glUniform4fv(prog.PrimFracLocation, 1, tempf2);
             OPENGL_CHECK_ERRORS;
         }

--- a/glide2gl/src/Glide64/Gfx_1.3.h
+++ b/glide2gl/src/Glide64/Gfx_1.3.h
@@ -140,7 +140,7 @@ void ReleaseGfx(void);
 
 // The highest 8 bits are the segment # (1-16), and the lower 24 bits are the offset to
 // add to it.
-#define segoffset(so) ((rdp.segment[(so>>24)&0x0f] + (so&BMASK)) & BMASK)
+#define segoffset(so) ((rdp.segment[((so)>>24)&0x0F] + ((so)&BMASK)) & BMASK)
 #define RSP_SegmentToPhysical(so) (((rdp.segment[(so>>24)&0x0f] + (so&BMASK)) & BMASK) & 0x00ffffff)
 
 /* Plugin types */

--- a/glide2gl/src/Glide64/TexCache.c
+++ b/glide2gl/src/Glide64/TexCache.c
@@ -1214,7 +1214,7 @@ static void LoadTex(int id, int tmu)
 
       // Load using mirroring/clamping
       if (min_x > texinfo[id].width &&
-            real_x > texinfo[id].width)
+  (signed)real_x > texinfo[id].width) /* real_x unsigned just for right shift */
       {
          if (size == 1)
             Clamp16bS ((texture), texinfo[id].width, min_x, real_x, texinfo[id].height);
@@ -1227,7 +1227,7 @@ static void LoadTex(int id, int tmu)
       if (texinfo[id].width < (int)real_x)
       {
          bool cond_true = rdp.tiles[td].mask_s != 0
-               && (real_x > (1 << rdp.tiles[td].mask_s));
+               && (real_x > (1U << rdp.tiles[td].mask_s));
          if (rdp.tiles[td].mirror_s && cond_true)
          {
             if (size == 1)
@@ -1273,7 +1273,7 @@ static void LoadTex(int id, int tmu)
          int32_t line_full = real_x << size;
          uint8_t *dst = (uint8_t*)(texture + texinfo[id].height * line_full);
          uint8_t *const_line = (uint8_t*)(dst - line_full);
-         uint32_t y = texinfo[id].height;
+         int y = texinfo[id].height;
 
          for (; y < min_y; y++)
          {
@@ -1287,7 +1287,7 @@ static void LoadTex(int id, int tmu)
          if (rdp.tiles[td].mirror_t)
          {
             // Vertical Mirror
-            if (rdp.tiles[td].mask_t != 0 && (real_y > (1 << rdp.tiles[td].mask_t)))
+            if (rdp.tiles[td].mask_t != 0 && (real_y > (1U << rdp.tiles[td].mask_t)))
             {
                uint32_t mask_height = (1 << rdp.tiles[td].mask_t);
                uint32_t mask_mask = mask_height-1;
@@ -1308,7 +1308,7 @@ static void LoadTex(int id, int tmu)
                }
             }
          }
-         else if (rdp.tiles[td].mask_t != 0 && real_y > (1 << rdp.tiles[td].mask_t))
+         else if (rdp.tiles[td].mask_t != 0 && real_y > (1U << rdp.tiles[td].mask_t))
          {
             // Vertical Wrap
             uint32_t wrap_size = size;

--- a/glide2gl/src/Glide64/TexCache.c
+++ b/glide2gl/src/Glide64/TexCache.c
@@ -146,7 +146,7 @@ static uint32_t textureCRC(uint8_t *addr, int width, int height, int line)
       for (i = width; i; --i)
       {
          twopixel_crc = i * (uint64_t)(pixelpos[1] + pixelpos[0] + crc);
-         crc = (twopixel_crc >> 32) + twopixel_crc;
+         crc = (uint32_t)(twopixel_crc >> 32) + (uint32_t)twopixel_crc;
          pixelpos += 2;
       }
       crc = ((unsigned int)height * (uint64_t)crc >> 32) + height * crc;

--- a/glide2gl/src/Glide64/glide64_gSP.h
+++ b/glide2gl/src/Glide64/glide64_gSP.h
@@ -391,8 +391,8 @@ static void draw_tri_depth(VERTEX **vtx)
       if ((rdp.rm & ZMODE_DECAL) == ZMODE_DECAL)
       {
          // Calculate deltaZ per polygon for Decal z-mode
-         float fdzdy = (diffz_02 * diffx_12 - diffz_12 * diffx_02) / denom;
-         float fdz = fabs(fdzdx) + fabs(fdzdy);
+         float fdzdy = (float)((diffz_02*diffx_12 - diffz_12*diffx_02) / denom);
+         float fdz = (float)(fabs(fdzdx) + fabs(fdzdy));
          if ((settings.hacks & hack_Zelda) && (rdp.rm & 0x800))
             fdz *= 4.0;  // Decal mode in Zelda sometimes needs mutiplied deltaZ to work correct, e.g. roads
          deltaZ = max(8, (int)fdz);

--- a/glide2gl/src/Glide64/glide64_gSP.h
+++ b/glide2gl/src/Glide64/glide64_gSP.h
@@ -533,7 +533,7 @@ static void draw_tri (VERTEX **vtx, uint16_t linew)
 
 static void cull_trianglefaces(VERTEX **v, unsigned iterations, bool do_update, bool do_cull, int32_t wd)
 {
-   int32_t i;
+   uint32_t i;
    int32_t vcount = 0;
 
    if (do_update)
@@ -591,7 +591,7 @@ static void pre_update(void)
  */
 static void gSPVertex(uint32_t addr, uint32_t n, uint32_t v0)
 {
-   int i;
+   unsigned int i;
    float x, y, z;
 #ifdef __ARM_NEON__
    float32x4_t comb0, comb1, comb2, comb3;

--- a/glide2gl/src/Glide64/glide64_rdp.c
+++ b/glide2gl/src/Glide64/glide64_rdp.c
@@ -847,14 +847,14 @@ static void rdp_texrect(uint32_t w0, uint32_t w1)
       lr_x += 1.0f;
       lr_y += 1.0f;
    } else if (lr_y - ul_y < 1.0f)
-      lr_y = ceil(lr_y);
+      lr_y = ceilf(lr_y);
 
    if (settings.increase_texrect_edge)
    {
       if (floor(lr_x) != lr_x)
-         lr_x = ceil(lr_x);
+         lr_x = ceilf(lr_x);
       if (floor(lr_y) != lr_y)
-         lr_y = ceil(lr_y);
+         lr_y = ceilf(lr_y);
    }
 
    //*/

--- a/glide2gl/src/Glide64/glide64_rdp.c
+++ b/glide2gl/src/Glide64/glide64_rdp.c
@@ -3141,7 +3141,7 @@ output:   none
 EXPORT void CALL ProcessRDPList(void)
 {
    int32_t length;
-   uint32_t i;
+   int32_t i;
    uint32_t cmd, cmd_length;
 
    rdp_cmd_ptr = 0;

--- a/glide2gl/src/Glide64/glide64_util.c
+++ b/glide2gl/src/Glide64/glide64_util.c
@@ -226,7 +226,7 @@ static void InterpolateColors3(VERTEX *v1, VERTEX *v2, VERTEX *v3, VERTEX *out)
    if (s2 > 100.0f)
       s2 =(ty-v2->sy)/(v3->sy-v2->sy);
 
-   w = 1.0/interp3p(v1->oow,v2->oow,v3->oow,s1,s2);
+   w = 1.0f / interp3p(v1->oow,v2->oow,v3->oow,s1,s2);
 
    out->r = (uint8_t)
       (w * interp3p(v1->r*v1->oow,v2->r*v2->oow,v3->r*v3->oow,s1,s2));
@@ -267,11 +267,11 @@ static INLINE void CalculateLODValues(VERTEX *v, int32_t i, int32_t j, float *lo
    float deltaS, deltaT, deltaTexels, deltaPixels, deltaX, deltaY;
    deltaS = (v[j].u0/v[j].q - v[i].u0/v[i].q) * s_scale;
    deltaT = (v[j].v0/v[j].q - v[i].v0/v[i].q) * t_scale;
-   deltaTexels = sqrt( deltaS * deltaS + deltaT * deltaT );
+   deltaTexels = sqrtf( deltaS * deltaS + deltaT * deltaT );
 
    deltaX = (v[j].x - v[i].x)/rdp.scale_x;
    deltaY = (v[j].y - v[i].y)/rdp.scale_y;
-   deltaPixels = sqrt( deltaX * deltaX + deltaY * deltaY );
+   deltaPixels = sqrtf( deltaX * deltaX + deltaY * deltaY );
 
    *lodFactor += deltaTexels / deltaPixels;
 }

--- a/glide2gl/src/Glide64/glidemain.c
+++ b/glide2gl/src/Glide64/glidemain.c
@@ -732,7 +732,7 @@ EXPORT void CALL UpdateScreen (void)
 
    if (
          (settings.frame_buffer & fb_cpu_write_hack) &&
-         (update_screen_count > ((settings.hacks&hack_Lego) ? 15 : 30)) &&
+         (update_screen_count > ((settings.hacks&hack_Lego) ? 15U : 30U)) &&
          (rdp.last_bg == 0)
       )
    {

--- a/glide2gl/src/Glide64/ucode00.h
+++ b/glide2gl/src/Glide64/ucode00.h
@@ -40,7 +40,7 @@
 
 static void rsp_vertex(int v0, int n)
 {
-   int i;
+   unsigned int i;
    uint32_t addr = segoffset(rdp.cmd1) & 0x00FFFFFF;
 
    // This is special, not handled in update(), but here

--- a/glide2gl/src/Glide64/ucode02.h
+++ b/glide2gl/src/Glide64/ucode02.h
@@ -150,7 +150,6 @@ static void uc2_modifyvtx(uint32_t w0, uint32_t w1)
 static void uc2_culldl(uint32_t w0, uint32_t w1)
 {
    uint16_t i, vStart, vEnd, cond;
-   VERTEX *v;
 
    vStart = (uint16_t)(w0 & 0xFFFF) >> 1;
    vEnd = (uint16_t)(w1 & 0xFFFF) >> 1;
@@ -163,6 +162,8 @@ static void uc2_culldl(uint32_t w0, uint32_t w1)
    for (i = vStart; i <= vEnd; i++)
    {
 #if 0
+      VERTEX *v;
+
       v = (VERTEX*)&rdp.vtx[i];
 
       /*

--- a/glide2gl/src/Glide64/ucode07.h
+++ b/glide2gl/src/Glide64/ucode07.h
@@ -65,7 +65,7 @@ typedef struct
 
 static void uc7_vertex(uint32_t w0, uint32_t w1)
 {
-   int i;
+   unsigned int i;
    float x, y, z;
 #ifdef __ARM_NEON__
    float32x4_t comb0, comb1, comb2, comb3;

--- a/glide2gl/src/Glide64/ucode08.h
+++ b/glide2gl/src/Glide64/ucode08.h
@@ -47,7 +47,7 @@ float uc8_coord_mod[16];
 static void uc8_vertex(uint32_t w0, uint32_t w1)
 {
    uint32_t l;
-   int32_t i;
+   uint32_t i;
    float x, y, z;
 #ifdef __ARM_NEON__
    float32x4_t comb0, comb1, comb2, comb3;

--- a/glide2gl/src/Glide64/ucode08.h
+++ b/glide2gl/src/Glide64/ucode08.h
@@ -46,7 +46,6 @@ float uc8_coord_mod[16];
 
 static void uc8_vertex(uint32_t w0, uint32_t w1)
 {
-   uint32_t l;
    uint32_t i;
    float x, y, z;
 #ifdef __ARM_NEON__

--- a/glide2gl/src/Glitch64/geometry.c
+++ b/glide2gl/src/Glitch64/geometry.c
@@ -131,7 +131,7 @@ grDepthBiasLevel( FxI32 level )
    LOG("grDepthBiasLevel(%d)\r\n", level);
    if (level)
    {
-      glPolygonOffset(polygonOffsetFactor, (float)level * settings.depth_bias * 0.01 );
+      glPolygonOffset(polygonOffsetFactor, (float)level * settings.depth_bias * 0.01f);
       glEnable(GL_POLYGON_OFFSET_FILL);
    }
    else
@@ -152,8 +152,10 @@ grDepthBiasLevel( FxI32 level )
 FX_ENTRY void FX_CALL
 grDrawVertexArrayContiguous(FxU32 mode, FxU32 count, void *pointers)
 {
-   VERTEX *v = (VERTEX*)pointers;
+#ifdef EMSCRIPTEN
    unsigned i;
+#endif
+   VERTEX *v = (VERTEX*)pointers;
 
    if(need_to_compile)
       compile_shader();

--- a/glide2gl/src/Glitch64/glitchmain.c
+++ b/glide2gl/src/Glitch64/glitchmain.c
@@ -190,9 +190,9 @@ grLfbLock( GrLock_t type, GrBuffer_t buffer, GrLfbWriteMode_t writeMode,
 
    if (writeMode == GR_LFBWRITEMODE_565)
    {
-      unsigned i,j;
-      glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, buf);
+      signed i, j;
 
+      glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, buf);
       for (j=0; j < height; j++)
       {
          for (i=0; i < width; i++)

--- a/mupen64plus-audio-libretro/resamplers/cc_resampler.c
+++ b/mupen64plus-audio-libretro/resamplers/cc_resampler.c
@@ -426,14 +426,14 @@ static INLINE float cc_int(float x, float b)
 {
    float val = x * b;
 #if (CC_RESAMPLER_PRECISION > 0)
-   val = val*(1 - 0.25 * val * val * (3.0 - val * val));
+   val = val * (1.00f - 0.25f*val*val*(3.00f - val*val));
 #endif
-   return (val > 0.5) ? 0.5 : (val < -0.5) ? -0.5 : val;
+   return (val > 0.5f) ? 0.5f : (val < -0.5f) ? -0.5f : val;
 }
 
 static INLINE float cc_kernel(float x, float b)
 {
-   return (cc_int(x + 0.5, b) - cc_int(x - 0.5, b));
+   return (cc_int(x + 0.5f, b) - cc_int(x - 0.5f, b));
 }
 #endif
 
@@ -453,8 +453,8 @@ static void resampler_CC_downsample(void *re_, struct resampler_data *data)
    audio_frame_float_t *inp_max = (audio_frame_float_t*)(inp + data->input_frames);
    audio_frame_float_t *outp    = (audio_frame_float_t*)data->data_out;
 
-   ratio = 1.0 / data->ratio;
-   b = data->ratio; /* cutoff frequency. */
+   ratio = (float)(1.0 / data->ratio);
+   b = (float)data->ratio; /* cutoff frequency. */
 
    while (inp != inp_max)
    {
@@ -492,8 +492,8 @@ static void resampler_CC_upsample(void *re_, struct resampler_data *data)
    audio_frame_float_t *inp_max = (audio_frame_float_t*)(inp + data->input_frames);
    audio_frame_float_t *outp    = (audio_frame_float_t*)data->data_out;
 
-   b = min(data->ratio, 1.00); /* cutoff frequency. */
-   ratio = 1.0 / data->ratio;
+   b = (float)min(data->ratio, 1.00f); /* cutoff frequency. */
+   ratio = (float)(1.0 / data->ratio);
 
    while (inp != inp_max)
    {
@@ -511,7 +511,7 @@ static void resampler_CC_upsample(void *re_, struct resampler_data *data)
 
          for (i = 0; i < 4; i++)
          {
-            temp = cc_kernel(re->distance + 1.0 - i, b);
+            temp = cc_kernel(re->distance + 1.0f - i, b);
             outp->l += re->buffer[i].l * temp;
             outp->r += re->buffer[i].r * temp;
          }

--- a/mupen64plus-audio-libretro/resamplers/nearest.c
+++ b/mupen64plus-audio-libretro/resamplers/nearest.c
@@ -28,7 +28,7 @@ static void resampler_nearest_process(void *re_,
    audio_frame_float_t *inp = (audio_frame_float_t*)data->data_in;
    audio_frame_float_t *inp_max = inp + data->input_frames;
    audio_frame_float_t *outp = (audio_frame_float_t*)data->data_out;
-   float ratio = 1.0/data->ratio;
+   float ratio = 1.0f / (float)(data -> ratio);
  
    while(inp != inp_max)
    {

--- a/mupen64plus-audio-libretro/resamplers/resampler.c
+++ b/mupen64plus-audio-libretro/resamplers/resampler.c
@@ -24,6 +24,9 @@
 #include "../../general.h"
 #endif
 
+/* strcasecmp not implemented in MSVC */
+#include "../libretro/msvc_compat.h"
+
 static const rarch_resampler_t *resampler_drivers[] = {
    &sinc_resampler,
    &CC_resampler,

--- a/mupen64plus-audio-libretro/utils.c
+++ b/mupen64plus-audio-libretro/utils.c
@@ -38,7 +38,8 @@ void audio_convert_s16_to_float_C(float *out,
 void audio_convert_float_to_s16_C(int16_t *out,
       const float *in, size_t samples)
 {
-   int i;
+   size_t i;
+
    for (i = 0; i < samples; i++)
    {
       int32_t val = (int32_t)(in[i] * 0x8000);

--- a/mupen64plus-core/src/r4300/x86_64/assemble.c
+++ b/mupen64plus-core/src/r4300/x86_64/assemble.c
@@ -119,7 +119,7 @@ void free_assembler(void **block_jumps_table, int *block_jumps_number, void **bl
 
 void passe2(precomp_instr *dest, int start, int end, precomp_block *block)
 {
-  unsigned int i;
+  int i;
 
   build_wrappers(dest, start, end, block);
 

--- a/mupen64plus-input-libretro/input_plugin.c
+++ b/mupen64plus-input-libretro/input_plugin.c
@@ -28,6 +28,15 @@
 
 #include "libretro.h"
 
+/* snprintf not available in MSVC 2010 and earlier */
+#include "../libretro/msvc_compat.h"
+
+/*
+ * copied straight from mupen64plus-core/src/r4300/fpu.h by cxd4
+ * Do not include said file above, as it currently will not compile.
+ */
+static __inline double round(double x) { return floor(x + 0.5); }
+
 extern retro_environment_t environ_cb;
 extern retro_input_state_t input_cb;
 extern struct retro_rumble_interface rumble;
@@ -317,7 +326,7 @@ static void inputGetKeys_reuse(int16_t analogX, int16_t analogY, int Control, BU
       // N64 Analog stick range is from -80 to 80
       radius *= 80.0 / ASTICK_MAX;
       // Convert back to cartesian coordinates
-      Keys->X_AXIS = (int32_t)round(radius * cos(angle));
+      Keys->X_AXIS = +(int32_t)round(radius * cos(angle));
       Keys->Y_AXIS = -(int32_t)round(radius * sin(angle));
    }
    else

--- a/mupen64plus-rsp-cxd4/rsp.c
+++ b/mupen64plus-rsp-cxd4/rsp.c
@@ -86,9 +86,10 @@ static void DebugMessage(int level, const char *message, ...)
 EXPORT m64p_error CALL PluginStartup(m64p_dynlib_handle CoreLibHandle, void *Context,
                                      void (*DebugCallback)(void *, int, const char *))
 {
+#ifndef __LIBRETRO__
     ptr_CoreGetAPIVersions CoreAPIVersionFunc;
-
     int ConfigAPIVersion, DebugAPIVersion, VidextAPIVersion, bSaveConfig;
+#endif
     float fConfigParamsVersion = 0.0f;
 
     if (l_PluginInit)

--- a/mupen64plus-rsp-hle/src/alist.c
+++ b/mupen64plus-rsp-hle/src/alist.c
@@ -91,7 +91,7 @@ static int16_t ramp_step(struct ramp_t* ramp)
         ramp->step  = 0;
     }
 
-    return (ramp->value >> 16);
+    return (int16_t)(ramp->value >> 16);
 }
 
 /* global functions */
@@ -338,16 +338,16 @@ void alist_envmix_exp(
         }
     }
 
-    *(int16_t *)(save_buffer +  0) = wet;               /* 0-1 */
-    *(int16_t *)(save_buffer +  2) = dry;               /* 2-3 */
-    *(int32_t *)(save_buffer +  4) = ramps[0].target;   /* 4-5 */
-    *(int32_t *)(save_buffer +  6) = ramps[1].target;   /* 6-7 */
-    *(int32_t *)(save_buffer +  8) = exp_rates[0];      /* 8-9 (save_buffer is a 16bit pointer) */
-    *(int32_t *)(save_buffer + 10) = exp_rates[1];      /* 10-11 */
-    *(int32_t *)(save_buffer + 12) = exp_seq[0];        /* 12-13 */
-    *(int32_t *)(save_buffer + 14) = exp_seq[1];        /* 14-15 */
-    *(int32_t *)(save_buffer + 16) = ramps[0].value;    /* 12-13 */
-    *(int32_t *)(save_buffer + 18) = ramps[1].value;    /* 14-15 */
+    *(int16_t *)(save_buffer +  0) = wet;                       /* 0-1 */
+    *(int16_t *)(save_buffer +  2) = dry;                       /* 2-3 */
+    *(int32_t *)(save_buffer +  4) = (int32_t)ramps[0].target;  /* 4-5 */
+    *(int32_t *)(save_buffer +  6) = (int32_t)ramps[1].target;  /* 6-7 */
+    *(int32_t *)(save_buffer +  8) = exp_rates[0];              /* 8-9 (save_buffer is a 16bit pointer) */
+    *(int32_t *)(save_buffer + 10) = exp_rates[1];              /* 10-11 */
+    *(int32_t *)(save_buffer + 12) = exp_seq[0];                /* 12-13 */
+    *(int32_t *)(save_buffer + 14) = exp_seq[1];                /* 14-15 */
+    *(int32_t *)(save_buffer + 16) = (int32_t)ramps[0].value;   /* 12-13 */
+    *(int32_t *)(save_buffer + 18) = (int32_t)ramps[1].value;   /* 14-15 */
 }
 
 void alist_envmix_ge(
@@ -415,16 +415,16 @@ void alist_envmix_ge(
         alist_envmix_mix(n, buffers, gains, in[k^S]);
     }
 
-    *(int16_t *)(save_buffer +  0) = wet;               /* 0-1 */
-    *(int16_t *)(save_buffer +  2) = dry;               /* 2-3 */
-    *(int32_t *)(save_buffer +  4) = ramps[0].target;   /* 4-5 */
-    *(int32_t *)(save_buffer +  6) = ramps[1].target;   /* 6-7 */
-    *(int32_t *)(save_buffer +  8) = ramps[0].step;     /* 8-9 (save_buffer is a 16bit pointer) */
-    *(int32_t *)(save_buffer + 10) = ramps[1].step;     /* 10-11 */
-    /**(int32_t *)(save_buffer + 12);*/                 /* 12-13 */
-    /**(int32_t *)(save_buffer + 14);*/                 /* 14-15 */
-    *(int32_t *)(save_buffer + 16) = ramps[0].value;    /* 12-13 */
-    *(int32_t *)(save_buffer + 18) = ramps[1].value;    /* 14-15 */
+    *(int16_t *)(save_buffer +  0) = wet;                       /* 0-1 */
+    *(int16_t *)(save_buffer +  2) = dry;                       /* 2-3 */
+    *(int32_t *)(save_buffer +  4) = (int32_t)ramps[0].target;  /* 4-5 */
+    *(int32_t *)(save_buffer +  6) = (int32_t)ramps[1].target;  /* 6-7 */
+    *(int32_t *)(save_buffer +  8) = (int32_t)ramps[0].step;    /* 8-9 (save_buffer is a 16bit pointer) */
+    *(int32_t *)(save_buffer + 10) = (int32_t)ramps[1].step;    /* 10-11 */
+ /* *(int32_t *)(save_buffer + 12); */                          /* 12-13 */
+ /* *(int32_t *)(save_buffer + 14); */                          /* 14-15 */
+    *(int32_t *)(save_buffer + 16) = (int32_t)ramps[0].value;   /* 12-13 */
+    *(int32_t *)(save_buffer + 18) = (int32_t)ramps[1].value;   /* 14-15 */
 }
 
 void alist_envmix_lin(
@@ -488,14 +488,14 @@ void alist_envmix_lin(
         alist_envmix_mix(4, buffers, gains, in[k^S]);
     }
 
-    *(int16_t *)(save_buffer +  0) = wet;            /* 0-1 */
-    *(int16_t *)(save_buffer +  2) = dry;            /* 2-3 */
-    *(int16_t *)(save_buffer +  4) = ramps[0].target >> 16; /* 4-5 */
-    *(int16_t *)(save_buffer +  6) = ramps[1].target >> 16; /* 6-7 */
-    *(int32_t *)(save_buffer +  8) = ramps[0].step;  /* 8-9 (save_buffer is a 16bit pointer) */
-    *(int32_t *)(save_buffer + 10) = ramps[1].step;  /* 10-11 */
-    *(int32_t *)(save_buffer + 16) = ramps[0].value; /* 16-17 */
-    *(int32_t *)(save_buffer + 18) = ramps[1].value; /* 18-19 */
+    *(int16_t *)(save_buffer +  0) = wet;                           /* 0-1 */
+    *(int16_t *)(save_buffer +  2) = dry;                           /* 2-3 */
+    *(int16_t *)(save_buffer +  4) = (ramps[0].target>>16)&0xFFFF;  /* 4-5 */
+    *(int16_t *)(save_buffer +  6) = (ramps[1].target>>16)&0xFFFF;  /* 6-7 */
+    *(int32_t *)(save_buffer +  8) = (int32_t)ramps[0].step;        /* 8-9 (save_buffer is a 16bit pointer) */
+    *(int32_t *)(save_buffer + 10) = (int32_t)ramps[1].step;        /* 10-11 */
+    *(int32_t *)(save_buffer + 16) = (int32_t)ramps[0].value;       /* 16-17 */
+    *(int32_t *)(save_buffer + 18) = (int32_t)ramps[1].value;       /* 18-19 */
 }
 
 void alist_envmix_nead(


### PR DESCRIPTION
Now that twinaphex has gotten the core to actually compile successfully in MSVC (excluding the build failures from the numerous linker errors we still have to work out), tens/hundreds of new level 2 and level 3 warnings have popped up in Visual Studio toolchain output when compiling.  These warnings, again, are not all necessarily significant; however many of them actually are indicative of potential bugs or even blissfully unintended precision loss.

The warnings which I did not fix are again ones related to knowledge the RetroArch API, or those remaining unused/unreferenced variable declarations which I could not find an apparent reason as to why they are unused (or no longer used??).

Other warnings I did not fix:  The C++ warnings in Mupen64Plus RiceVideo.
`...mupen64plus-libretro\gles2rice\src\RDP_Texture.h(554): warning C4806: '==' :`
`unsafe operation: no value of type 'bool' promoted to type 'SetTileCmdType' can equal the given constant`
(repeated 8 other times over the file)

That amount of unreachable code could explain some serious regressions since the OpenGL port of Rice's Video Plugin.  [Of course, this could never have happened if we didn't have such a funny little made up arbitrarily built-in type like `bool`. :)]

Also, the "performance warning" MSVC keeps shooting off repeatedly in RiceVideo, about data moves from the return slot of a function (`int`) into `bool` storage, which again makes me glad we have this little piece of C++ capability to save the day.  Fixing these warnings just by forcing an explicit type cast would only be masking the deficiency; the whole code should probably be rewritten to use mostly integers but never `bool`, with some `typedef` for special integers with only two possible values, rather than a built-in C++ or C99 type with the (albeit relatively minor) instruction sizeability and performance compromises for abstraction like this.

Last and not least, there were also a few link-time failures connected to warnings about unresolved extern functions due to source files being moved around since the last attempts at supporting MSVC (and also Microsoft's refusal to support some POSIX and plenty of C99 things).
