### PR TITLE
Move the round declaration before math include

### DIFF
--- a/mupen64plus-input-libretro/input_plugin.c
+++ b/mupen64plus-input-libretro/input_plugin.c
@@ -24,18 +24,19 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <math.h>
-
-#include "libretro.h"
-
-/* snprintf not available in MSVC 2010 and earlier */
-#include "../libretro/msvc_compat.h"
 
 /*
  * copied straight from mupen64plus-core/src/r4300/fpu.h by cxd4
  * Do not include said file above, as it currently will not compile.
  */
 static __inline double round(double x) { return floor(x + 0.5); }
+
+#include <math.h>
+
+#include "libretro.h"
+
+/* snprintf not available in MSVC 2010 and earlier */
+#include "../libretro/msvc_compat.h"
 
 extern retro_environment_t environ_cb;
 extern retro_input_state_t input_cb;


### PR DESCRIPTION
due to gcc error: static declaration of ‘round’ follows non-static declaration

<pre>
mupen64plus-input-libretro/input_plugin.c:38:24: error: static declaration of ‘round’ follows non-static declaration
 static __inline double round(double x) { return floor(x + 0.5); }
</pre>


Environment:
- Fedora20
- gcc version 4.8.3 20140911 (Red Hat 4.8.3-7) (GCC)
