### PR TITLE
Fix almost all of the link-time build errors in MSVC.

### DIFF
--- a/angrylionrdp/n64video_main.c
+++ b/angrylionrdp/n64video_main.c
@@ -8,7 +8,7 @@
 #include "m64p_types.h"
 #include "m64p_config.h"
 
-extern int screen_width, screen_height;
+extern unsigned int screen_width, screen_height;
 extern uint32_t screen_pitch;
 
 #ifdef HAVE_DIRECTDRAW

--- a/glide2gl/src/Glide64/CRC.h
+++ b/glide2gl/src/Glide64/CRC.h
@@ -47,6 +47,6 @@
 #define GLIDE64_CRC32_H
 
 void CRC_Glide64_BuildTable(void);
-unsigned int CRC32( unsigned int crc, void *buffer, unsigned int count );
+extern unsigned int CRC32(unsigned int crc, void *buffer, unsigned int count);
 
 #endif

--- a/glide2gl/src/Glide64/Gfx_1.3.h
+++ b/glide2gl/src/Glide64/Gfx_1.3.h
@@ -170,8 +170,8 @@ extern bool no_dlist;
 
 
 int GetTexAddrUMA(int tmu, int texsize);
-void ReadSettings(void);
-void ReadSpecialSettings (const char * name);
+extern void ReadSettings(void);
+extern void ReadSpecialSettings(const char * name);
 
 extern void (*_gSPVertex)(uint32_t addr, uint32_t n, uint32_t v0);
 

--- a/glide2gl/src/Glide64/Glide64_UCode.h
+++ b/glide2gl/src/Glide64/Glide64_UCode.h
@@ -112,6 +112,6 @@
 #define UCODE_ODT_PROTO                      0x9551177b
 #define UCODE_LAST_LEGION_UX                 0xff372492
 
-void microcheck(void);
+extern void microcheck(void);
 
 #endif

--- a/libretro/msvc/msvc-2010/msvc-2010.vcxproj
+++ b/libretro/msvc/msvc-2010/msvc-2010.vcxproj
@@ -55,6 +55,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -73,6 +74,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/mupen64plus-input-libretro/input_plugin.c
+++ b/mupen64plus-input-libretro/input_plugin.c
@@ -25,13 +25,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-/*
- * copied straight from mupen64plus-core/src/r4300/fpu.h by cxd4
- * Do not include said file above, as it currently will not compile.
- */
-static __inline double round(double x) { return floor(x + 0.5); }
-
 #include <math.h>
+#define ROUND(x)    floor((x) + 0.5)
 
 #include "libretro.h"
 
@@ -327,8 +322,8 @@ static void inputGetKeys_reuse(int16_t analogX, int16_t analogY, int Control, BU
       // N64 Analog stick range is from -80 to 80
       radius *= 80.0 / ASTICK_MAX;
       // Convert back to cartesian coordinates
-      Keys->X_AXIS = +(int32_t)round(radius * cos(angle));
-      Keys->Y_AXIS = -(int32_t)round(radius * sin(angle));
+      Keys->X_AXIS = +(int32_t)ROUND(radius * cos(angle));
+      Keys->Y_AXIS = -(int32_t)ROUND(radius * sin(angle));
    }
    else
    {


### PR DESCRIPTION
Almost all of them were OpenGL references, unresolved simply because the makefile did not specify Win32 opengl32.lib in the linker input options.  A couple of them were complaints that angrylionrdp had screen_width and screen_height declared as `int`'s, but `uint32_t`'s throughout the entirety of the rest of the libretro source for this core.  I highlighted 4 remaining unresolved references, which frankly, I am not sure why they are unresolved...I may have to spend a lot more time differentiating how MinGW ordered the linker objects or how the GNU makefile was set up to understand what could be going wrong there.

The other 8 unresolved symbols are all from the C++ portion of this repository--the mupen64plus port of Rice video (which remains ever-so-broken for quite some time).  For some reason, it's as if MSVC doesn't want to understand external references to C object functions, from within a C++ compiled object.  Don't know what's going on there either as well.
