### PR TITLE
Add additional country codes. Should make all PAL games run properly.

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -378,6 +378,14 @@ static m64p_system_type rom_country_code_to_system_type(unsigned short country_c
         case 0x55:
         case 0x58:
         case 0x59:
+        case 0x144:
+        case 0x146:
+        case 0x149:
+        case 0x150:
+        case 0x153:
+        case 0x155:
+        case 0x158:
+        case 0x159:
             return SYSTEM_PAL;
 
         // NTSC codes
@@ -385,6 +393,10 @@ static m64p_system_type rom_country_code_to_system_type(unsigned short country_c
         case 0x41:
         case 0x45:
         case 0x4a:
+        case 0x137:
+        case 0x141:
+        case 0x145:
+        case 0x14a:
         default: // Fallback for unknown codes
             return SYSTEM_NTSC;
     }

--- a/mupen64plus-core/src/main/rom.c
+++ b/mupen64plus-core/src/main/rom.c
@@ -324,6 +324,14 @@ static m64p_system_type rom_country_code_to_system_type(unsigned short country_c
         case 0x55:
         case 0x58:
         case 0x59:
+        case 0x144:
+        case 0x146:
+        case 0x149:
+        case 0x150:
+        case 0x153:
+        case 0x155:
+        case 0x158:
+        case 0x159:
             return SYSTEM_PAL;
 
         // NTSC codes
@@ -331,6 +339,10 @@ static m64p_system_type rom_country_code_to_system_type(unsigned short country_c
         case 0x41:
         case 0x45:
         case 0x4a:
+        case 0x137:
+        case 0x141:
+        case 0x145:
+        case 0x14a:
         default: // Fallback for unknown codes
             return SYSTEM_NTSC;
     }


### PR DESCRIPTION
I'm not entirely sure why these codes haven't been included in Mupen64Plus before as they appear in several No-Intro verified roms, my guess is that PAL detection works differently between mainline and libretro which means nobody ever really noticed this before.
Since unknown country codes always result booting into NTSC this only affected PAL games.

Examples:
Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev A) uses "0x150"
Diddy Kong Racing (USA) (En,Fr) (Rev A) uses "0x145"

Closes https://github.com/libretro/mupen64plus-libretro/issues/80 and https://github.com/libretro/mupen64plus-libretro/issues/81
