### PR TITLE
new_dynarec: Disable CORTEX_A8_BRANCH_PREDICTION_HACK if ARMv5_ONLY is d...

### DIFF
--- a/mupen64plus-core/src/r4300/new_dynarec/assem_arm.h
+++ b/mupen64plus-core/src/r4300/new_dynarec/assem_arm.h
@@ -8,7 +8,9 @@
 
 #define HOST_IMM8 1
 #define HAVE_CMOV_IMM 1
+#ifndef ARMv5_ONLY
 #define CORTEX_A8_BRANCH_PREDICTION_HACK 1
+#endif
 #define USE_MINI_HT 1
 //#define REG_PREFETCH 1
 #define HAVE_CONDITIONAL_CALL 1


### PR DESCRIPTION
...efined

ARMv5 or v6 don't need this hack.
