### PR TITLE
Add RPI2 target and get it running for now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,12 @@ else ifneq (,$(findstring rpi,$(platform)))
 	GLES = 1
 	GL_LIB := -L/opt/vc/lib -lGLESv2
 	INCFLAGS += -I/opt/vc/include
-	CPUFLAGS += -DARMv5_ONLY -DNO_ASM
+	ifneq (,$(findstring rpi2,$(platform)))
+		CPUFLAGS += -DNO_ASM -DARM -D__arm__ -DARM_ASM -D__NEON_OPT -DNOSSE
+		HAVE_NEON=1
+	else
+		CPUFLAGS += -DARMv5_ONLY -DNO_ASM
+	endif
 	PLATFORM_EXT := unix
 	WITH_DYNAREC=arm
 

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ else ifneq (,$(findstring rpi,$(platform)))
 	INCFLAGS += -I/opt/vc/include
 	ifneq (,$(findstring rpi2,$(platform)))
 		CPUFLAGS += -DNO_ASM -DARM -D__arm__ -DARM_ASM -D__NEON_OPT -DNOSSE
-		HAVE_NEON=1
+		# HAVE_NEON=1
 	else
 		CPUFLAGS += -DARMv5_ONLY -DNO_ASM
 	endif

--- a/gles2rice/src/RenderBase.cpp
+++ b/gles2rice/src/RenderBase.cpp
@@ -275,7 +275,7 @@ void NormalizeNormalVec()
 
 void InitRenderBase()
 {
-#if defined(__ARM_NEON__)
+#if defined(HAVE_NEON)
     if( !g_curRomInfo.bPrimaryDepthHack && options.enableHackForGames != HACK_FOR_NASCAR && options.enableHackForGames != HACK_FOR_ZELDA_MM && !options.bWinFrameMode)
     {
         ProcessVertexData = ProcessVertexDataNEON;
@@ -550,7 +550,7 @@ static noinline void InitVertex_texgen_correct(TLITVERTEX &v, uint32_t dwV)
 }
 
 #include "RenderBase_neon.h"
-#ifndef __ARM_NEON__
+#ifndef HAVE_NEON
 static void multiply_subtract2(float *d, const float *m1, const float *m2, const float *s)
 {
     int i;
@@ -900,7 +900,7 @@ void ProcessVertexDataNoSSE(uint32_t dwAddr, uint32_t dwV0, uint32_t dwNum)
     DEBUGGER_PAUSE_AND_DUMP(NEXT_VERTEX_CMD,{TRACE0("Paused at Vertex Command");});
 }
 
-#ifdef __ARM_NEON__
+#ifdef HAVE_NEON
 /* NEON code */
 
 #include "RenderBase_neon.h"
@@ -1124,7 +1124,7 @@ bool IsTriangleVisible(uint32_t dwV0, uint32_t dwV1, uint32_t dwV2)
         // method doesn't work well when the z value is outside of screenspace
         //if (v0.z < 1 && v1.z < 1 && v2.z < 1)
         {
-#ifndef __ARM_NEON__
+#ifndef HAVE_NEON
             float V1 = v2.x - v0.x;
             float V2 = v2.y - v0.y;
 

--- a/gles2rice/src/RenderBase_neon.S
+++ b/gles2rice/src/RenderBase_neon.S
@@ -5,7 +5,7 @@
  * See the COPYING file in the top-level directory.
  */
 
-#if defined(__ARCH_ARM) || defined(__ARM_EABI__) || defined(__ARM_NEON__)
+#if defined(__ARCH_ARM) || defined(__ARM_EABI__) || defined(HAVE_NEON)
 
 #include "arm_features.h"
 #include "RenderBase_neon.h"

--- a/mupen64plus-audio-libretro/audio_utils.c
+++ b/mupen64plus-audio-libretro/audio_utils.c
@@ -221,7 +221,7 @@ void audio_convert_float_to_s16_altivec(int16_t *out,
    }
    audio_convert_float_to_s16_C(out, in, samples_in);
 }
-#elif defined(__ARM_NEON__)
+#elif defined(HAVE_NEON)
 /* Avoid potential hard-float/soft-float ABI issues. */
 void audio_convert_s16_float_asm(float *out, const int16_t *in,
       size_t samples, const float *gain);
@@ -432,7 +432,7 @@ void audio_convert_init_simd(void)
    unsigned cpu = audio_convert_get_cpu_features();
 
    (void)cpu;
-#if defined(__ARM_NEON__) 
+#if defined(HAVE_NEON) 
    audio_convert_s16_to_float_arm = cpu & RETRO_SIMD_NEON ?
       audio_convert_s16_to_float_neon : audio_convert_s16_to_float_C;
    audio_convert_float_to_s16_arm = cpu & RETRO_SIMD_NEON ?

--- a/mupen64plus-audio-libretro/audio_utils.h
+++ b/mupen64plus-audio-libretro/audio_utils.h
@@ -93,7 +93,7 @@ void audio_convert_s16_to_float_altivec(float *out,
 void audio_convert_float_to_s16_altivec(int16_t *out,
       const float *in, size_t samples);
 
-#elif defined(__ARM_NEON__)
+#elif defined(HAVE_NEON)
 #define audio_convert_s16_to_float audio_convert_s16_to_float_arm
 #define audio_convert_float_to_s16 audio_convert_float_to_s16_arm
 

--- a/mupen64plus-audio-libretro/audio_utils_neon.S
+++ b/mupen64plus-audio-libretro/audio_utils_neon.S
@@ -12,7 +12,7 @@
  *  You should have received a copy of the GNU General Public License along with RetroArch.
  *  If not, see <http://www.gnu.org/licenses/>.
  */
-#if defined(__ARM_NEON__)
+#if defined(HAVE_NEON)
 
 #ifndef __MACH__
 .arm

--- a/mupen64plus-audio-libretro/drivers_resampler/cc_resampler.c
+++ b/mupen64plus-audio-libretro/drivers_resampler/cc_resampler.c
@@ -379,7 +379,7 @@ static void resampler_CC_upsample(void *re_, struct resampler_data *data)
 }
 
 
-#elif defined (__ARM_NEON__)
+#elif defined (HAVE_NEON)
 
 #define CC_RESAMPLER_IDENT "NEON"
 

--- a/mupen64plus-audio-libretro/drivers_resampler/cc_resampler_neon.S
+++ b/mupen64plus-audio-libretro/drivers_resampler/cc_resampler_neon.S
@@ -13,7 +13,7 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#if defined(__ARM_NEON__)
+#if defined(HAVE_NEON)
 
 #ifndef CC_RESAMPLER_PRECISION
 #define CC_RESAMPLER_PRECISION 1

--- a/mupen64plus-audio-libretro/drivers_resampler/sinc.c
+++ b/mupen64plus-audio-libretro/drivers_resampler/sinc.c
@@ -392,7 +392,7 @@ static void process_sinc(rarch_sinc_resampler_t *resamp, float *out_buffer)
    /* movehl { X, R, X, L } == { X, R, X, R } */
    _mm_store_ss(out_buffer + 1, _mm_movehl_ps(sum, sum));
 }
-#elif defined(__ARM_NEON__)
+#elif defined(HAVE_NEON)
 
 #if SINC_COEFF_LERP
 #error "NEON asm does not support SINC lerp."
@@ -497,7 +497,7 @@ static void *resampler_sinc_new(const struct resampler_config *config,
    }
 
    /* Be SIMD-friendly. */
-#if (defined(__AVX__) && ENABLE_AVX) || defined(__ARM_NEON__)
+#if (defined(__AVX__) && ENABLE_AVX) || defined(HAVE_NEON)
    re->taps = (re->taps + 7) & ~7;
 #else
    re->taps = (re->taps + 3) & ~3;
@@ -521,7 +521,7 @@ static void *resampler_sinc_new(const struct resampler_config *config,
    init_sinc_table(re, cutoff, re->phase_table,
          1 << PHASE_BITS, re->taps, SINC_COEFF_LERP);
 
-#if defined(__ARM_NEON__)
+#if defined(HAVE_NEON)
    process_sinc_func = mask & RESAMPLER_SIMD_NEON 
       ? process_sinc_neon : process_sinc_C;
 #endif

--- a/mupen64plus-audio-libretro/drivers_resampler/sinc_neon.S
+++ b/mupen64plus-audio-libretro/drivers_resampler/sinc_neon.S
@@ -12,7 +12,7 @@
  *  You should have received a copy of the GNU General Public License along with RetroArch.
  *  If not, see <http://www.gnu.org/licenses/>.
  */
-#if defined(__ARM_NEON__)
+#if defined(HAVE_NEON)
 
 #ifndef __MACH__
 .arm


### PR DESCRIPTION
RPI2 target was not compatible with __ARM_NEON__ definitions in gles2rice and mupen64plus-audio-libretro. I replaced __ARM_NEON__ with HAVE_NEON. HAVE_NEON is defined in your Makefile:
https://github.com/gizmo98/mupen64plus-libretro/blob/patch-2/Makefile#L260

I don't no why HAVE_NEON is not working with RPI2. __NEON_OPT is working.
