### PR TITLE
Force CFLAGS on rpi2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ else ifneq (,$(findstring rpi,$(platform)))
 	INCFLAGS += -I/opt/vc/include
 	ifneq (,$(findstring rpi2,$(platform)))
 		CPUFLAGS += -DNO_ASM -DARM -D__arm__ -DARM_ASM -D__NEON_OPT -DNOSSE
+		CFLAGS = -mcpu=cortex-a7 -mfloat-abi=hard
 		# HAVE_NEON=1
 	else
 		CPUFLAGS += -DARMv5_ONLY -DNO_ASM


### PR DESCRIPTION
Force CFLAGS without neon-vfp4/neon, so the compiler won't enable __ARM_NEON__ (cause segfault or no sound depending on distro)
