### PR TITLE
Revert "Minor fixes and cleanups"

### DIFF
--- a/glide2gl/src/Glide64/Glide64_Ini.c
+++ b/glide2gl/src/Glide64/Glide64_Ini.c
@@ -59,23 +59,7 @@ void ReadSpecialSettings (const char * name)
 
    fprintf(stderr, "ReadSpecialSettings: %s\n", name);
 
-   /* frame buffer */
-   smart_read = 0;
-   hires = 0;
-   get_fbinfo = 0;
-   read_always = 0;
-   depth_render = 1;
-   fb_crc_mode = 1;
-   read_back_to_screen = 0;
-   cpu_write_hack = 0;
-   optimize_texrect = 1;
-   hires_buf_clear = 0;
-   read_alpha = 0;
-   ignore_aux_copy = 0;
-   useless_is_useless = 0;
-
    updated = false;
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
       update_variables(false);
    
@@ -86,7 +70,21 @@ void ReadSpecialSettings (const char * name)
       settings.swapmode = 1;
       settings.lodmode = 0;
 
-      /* frame buffer */
+      //frame buffer
+      smart_read = 0;
+      hires = 0;
+      get_fbinfo = 0;
+      read_always = 0;
+      depth_render = 1;
+      fb_crc_mode = 1;
+      read_back_to_screen = 0; 
+      cpu_write_hack = 0;
+      optimize_texrect = 1;
+      hires_buf_clear = 0;
+      read_alpha = 0;
+      ignore_aux_copy = 0;
+      useless_is_useless = 0;
+
       settings.alt_tex_size = 0;
       settings.force_microcheck = 0;
       settings.force_quad3d = 0;

--- a/glide2gl/src/Glide64/TexLoad16b.h
+++ b/glide2gl/src/Glide64/TexLoad16b.h
@@ -62,8 +62,8 @@ static INLINE void load16bRGBA(uint8_t *src, uint8_t *dst, int wid_64, int heigh
     v9 = wid_64;
     do
     {
-      v10 = m64p_swap32(*v6);
-      v11 = m64p_swap32(v6[1]);
+      v10 = bswap32(*v6);
+      v11 = bswap32(v6[1]);
       ALOWORD(v10) = __ROR16((uint16_t)v10, 1, NBITS16_16B);
       ALOWORD(v11) = __ROR16((uint16_t)v11, 1, NBITS16_16B);
       v10 = __ROR32(v10, 16, NBITS32_16B);
@@ -85,8 +85,8 @@ static INLINE void load16bRGBA(uint8_t *src, uint8_t *dst, int wid_64, int heigh
     v14 = wid_64;
     do
     {
-      v15 = m64p_swap32(v12[1]);
-      v16 = m64p_swap32(*v12);
+      v15 = bswap32(v12[1]);
+      v16 = bswap32(*v12);
       ALOWORD(v15) = __ROR16((uint16_t)v15, 1, NBITS16_16B);
       ALOWORD(v16) = __ROR16((uint16_t)v16, 1, NBITS16_16B);
       v15 = __ROR32(v15, 16, NBITS32_16B);

--- a/glide2gl/src/Glide64/TexLoad4b.h
+++ b/glide2gl/src/Glide64/TexLoad4b.h
@@ -70,7 +70,7 @@ static INLINE void load4bCI(uint8_t *src, uint8_t *dst, int wid_64, int height, 
     do
     {
       v11 = v10;
-      v12 = m64p_swap32(*(uint32_t *)v7);
+      v12 = bswap32(*(uint32_t *)v7);
       v13 = v7 + 4;
       ALOWORD(v10) = __ROR16(*(uint16_t *)((char *)pal + ((v12 >> 23) & 0x1E)), 1, NBITS_4B);
       v14 = v10 << 16;
@@ -92,7 +92,7 @@ static INLINE void load4bCI(uint8_t *src, uint8_t *dst, int wid_64, int height, 
       ALOWORD(v14) = __ROR16(*(uint16_t *)((char *)pal + ((v12 >> 3) & 0x1E)), 1, NBITS_4B);
       *v15 = v14;
       ++v15;
-      v16 = m64p_swap32(*(uint32_t *)v13);
+      v16 = bswap32(*(uint32_t *)v13);
       v7 = v13 + 4;
       ALOWORD(v14) = __ROR16(*(uint16_t *)((char *)pal + ((v16 >> 23) & 0x1E)), 1, NBITS_4B);
       v14 <<= 16;
@@ -126,7 +126,7 @@ static INLINE void load4bCI(uint8_t *src, uint8_t *dst, int wid_64, int height, 
     do
     {
       v20 = v19;
-      v21 = m64p_swap32(*((uint32_t *)v17 + 1));
+      v21 = bswap32(*((uint32_t *)v17 + 1));
       ALOWORD(v19) = __ROR16(*(uint16_t *)((char *)pal + ((v21 >> 23) & 0x1E)), 1, NBITS_4B);
       v22 = v19 << 16;
       ALOWORD(v22) = __ROR16(*(uint16_t *)((char *)pal + ((v21 >> 27) & 0x1E)), 1, NBITS_4B);
@@ -147,7 +147,7 @@ static INLINE void load4bCI(uint8_t *src, uint8_t *dst, int wid_64, int height, 
       ALOWORD(v22) = __ROR16(*(uint16_t *)((char *)pal + ((v21 >> 3) & 0x1E)), 1, NBITS_4B);
       *v23 = v22;
       ++v23;
-      v24 = m64p_swap32(*(uint32_t *)v17);
+      v24 = bswap32(*(uint32_t *)v17);
       v17 = &src[((uintptr_t)v17 + 8 - (uintptr_t)src) & 0x7FF];
       ALOWORD(v22) = __ROR16(*(uint16_t *)((char *)pal + ((v24 >> 23) & 0x1E)), 1, NBITS_4B);
       v22 <<= 16;
@@ -209,7 +209,7 @@ static INLINE void load4bIAPal(uint8_t *src, uint8_t *dst, int wid_64, int heigh
     do
     {
       v11 = v10;
-      v12 = m64p_swap32(*(uint32_t *)v7);
+      v12 = bswap32(*(uint32_t *)v7);
       v13 = (uint32_t *)(v7 + 4);
       ALOWORD(v10) = __ROR16(*(uint16_t *)((char *)pal + ((v12 >> 23) & 0x1E)), 8, NBITS_4B);
       v14 = v10 << 16;
@@ -231,7 +231,7 @@ static INLINE void load4bIAPal(uint8_t *src, uint8_t *dst, int wid_64, int heigh
       ALOWORD(v14) = __ROR16(*(uint16_t *)((char *)pal + ((v12 >> 3) & 0x1E)), 8, NBITS_4B);
       *v15 = v14;
       ++v15;
-      v16 = m64p_swap32(*v13);
+      v16 = bswap32(*v13);
       v7 = (uint8_t *)(v13 + 1);
       ALOWORD(v14) = __ROR16(*(uint16_t *)((char *)pal + ((v16 >> 23) & 0x1E)), 8, NBITS_4B);
       v14 <<= 16;
@@ -265,7 +265,7 @@ static INLINE void load4bIAPal(uint8_t *src, uint8_t *dst, int wid_64, int heigh
     do
     {
       v20 = v19;
-      v21 = m64p_swap32(*((uint32_t *)v17 + 1));
+      v21 = bswap32(*((uint32_t *)v17 + 1));
       ALOWORD(v19) = __ROR16(*(uint16_t *)((char *)pal + ((v21 >> 23) & 0x1E)), 8, NBITS_4B);
       v22 = v19 << 16;
       ALOWORD(v22) = __ROR16(*(uint16_t *)((char *)pal + ((v21 >> 27) & 0x1E)), 8, NBITS_4B);
@@ -286,7 +286,7 @@ static INLINE void load4bIAPal(uint8_t *src, uint8_t *dst, int wid_64, int heigh
       ALOWORD(v22) = __ROR16(*(uint16_t *)((char *)pal + ((v21 >> 3) & 0x1E)), 8, NBITS_4B);
       *v23 = v22;
       ++v23;
-      v24 = m64p_swap32(*(uint32_t *)v17);
+      v24 = bswap32(*(uint32_t *)v17);
       v17 = &src[((uintptr_t)v17 + 8 - (uintptr_t)src) & 0x7FF];
       ALOWORD(v22) = __ROR16(*(uint16_t *)((char *)pal + ((v24 >> 23) & 0x1E)), 8, NBITS_4B);
       v22 <<= 16;
@@ -384,7 +384,7 @@ static INLINE void load4bIA(uint8_t *src, uint8_t *dst, int wid_64, int height, 
     do
     {
       v10 = v9;
-      v11 = m64p_swap32(*v6);
+      v11 = bswap32(*v6);
       v12 = v6 + 1;
       v13 = v11;
       v14 = (8 * (v11 & 0x100000)) | (4 * (v11 & 0x100000)) | (2 * (v11 & 0x100000)) | (v11 & 0x100000) | ((((v11 >> 16) & 0xE00) >> 3) & 0x100) | ((v11 >> 16) & 0xE00) | (8 * ((v11 >> 12) & 0x1000)) | (4 * ((v11 >> 12) & 0x1000)) | (2 * ((v11 >> 12) & 0x1000)) | ((v11 >> 12) & 0x1000) | ((((v11 >> 28) & 0xE) >> 3)) | ((v11 >> 28) & 0xE) | (8 * ((v11 >> 24) & 0x10)) | (4 * ((v11 >> 24) & 0x10)) | (2 * ((v11 >> 24) & 0x10)) | ((v11 >> 24) & 0x10);
@@ -404,7 +404,7 @@ static INLINE void load4bIA(uint8_t *src, uint8_t *dst, int wid_64, int height, 
       v21 >>= 3;
       *v16 = ((((v13 << 24) & 0xE000000) >> 3) & 0x1000000) | ((v13 << 24) & 0xE000000) | (8 * ((v13 << 28) & 0x10000000)) | (4 * ((v13 << 28) & 0x10000000)) | (2 * ((v13 << 28) & 0x10000000)) | ((v13 << 28) & 0x10000000) | (v21 & 0x10000) | v22;
       ++v16;
-      v23 = m64p_swap32(*v12);
+      v23 = bswap32(*v12);
       v6 = v12 + 1;
       v24 = v23;
       v25 = (8 * (v23 & 0x100000)) | (4 * (v23 & 0x100000)) | (2 * (v23 & 0x100000)) | (v23 & 0x100000) | ((((v23 >> 16) & 0xE00) >> 3) & 0x100) | ((v23 >> 16) & 0xE00) | (8 * ((v23 >> 12) & 0x1000)) | (4 * ((v23 >> 12) & 0x1000)) | (2 * ((v23 >> 12) & 0x1000)) | ((v23 >> 12) & 0x1000) | (((v23 >> 28) & 0xE) >> 3) | ((v23 >> 28) & 0xE) | (8 * ((v23 >> 24) & 0x10)) | (4 * ((v23 >> 24) & 0x10)) | (2 * ((v23 >> 24) & 0x10)) | ((v23 >> 24) & 0x10);
@@ -436,7 +436,7 @@ static INLINE void load4bIA(uint8_t *src, uint8_t *dst, int wid_64, int height, 
     do
     {
       v36 = v35;
-      v37 = m64p_swap32(v33[1]);
+      v37 = bswap32(v33[1]);
       v38 = v37 >> 4;
       v38 &= 0xE0000u;
       v39 = v38 | (8 * (v37 & 0x100000)) | (4 * (v37 & 0x100000)) | (2 * (v37 & 0x100000)) | (v37 & 0x100000) | ((((v37 >> 16) & 0xE00) >> 3) & 0x100) | ((v37 >> 16) & 0xE00) | (8 * ((v37 >> 12) & 0x1000)) | (4 * ((v37 >> 12) & 0x1000)) | (2 * ((v37 >> 12) & 0x1000)) | ((v37 >> 12) & 0x1000) | (((v37 >> 28) & 0xE) >> 3) | ((v37 >> 28) & 0xE) | (8 * ((v37 >> 24) & 0x10)) | (4 * ((v37 >> 24) & 0x10)) | (2 * ((v37 >> 24) & 0x10)) | ((v37 >> 24) & 0x10);
@@ -453,7 +453,7 @@ static INLINE void load4bIA(uint8_t *src, uint8_t *dst, int wid_64, int height, 
       v45 >>= 3;
       *v40 = ((((v37 << 24) & 0xE000000) >> 3) & 0x1000000) | ((v37 << 24) & 0xE000000) | (8 * ((v37 << 28) & 0x10000000)) | (4 * ((v37 << 28) & 0x10000000)) | (2 * ((v37 << 28) & 0x10000000)) | ((v37 << 28) & 0x10000000) | (v45 & 0x10000) | v46;
       ++v40;
-      v47 = m64p_swap32(*v33);
+      v47 = bswap32(*v33);
       v33 += 2;
       v48 = v47;
       v49 = (8 * (v47 & 0x100000)) | (4 * (v47 & 0x100000)) | (2 * (v47 & 0x100000)) | (v47 & 0x100000) | ((((v47 >> 16) & 0xE00) >> 3) & 0x100) | ((v47 >> 16) & 0xE00) | (8 * ((v47 >> 12) & 0x1000)) | (4 * ((v47 >> 12) & 0x1000)) | (2 * ((v47 >> 12) & 0x1000)) | ((v47 >> 12) & 0x1000) | (((v47 >> 28) & 0xE) >> 3) | ((v47 >> 28) & 0xE) | (8 * ((v47 >> 24) & 0x10)) | (4 * ((v47 >> 24) & 0x10)) | (2 * ((v47 >> 24) & 0x10)) | ((v47 >> 24) & 0x10);
@@ -522,7 +522,7 @@ static INLINE void load4bI(uint8_t *src, uint8_t *dst, int wid_64, int height, i
     do
     {
       v10 = v9;
-      v11 = m64p_swap32(*v6);
+      v11 = bswap32(*v6);
       v12 = v6 + 1;
       v13 = v11;
       v14 = (16 * ((v11 >> 16) & 0xF00)) | ((v11 >> 16) & 0xF00) | (16 * (v11 >> 28)) | (v11 >> 28);
@@ -532,7 +532,7 @@ static INLINE void load4bI(uint8_t *src, uint8_t *dst, int wid_64, int height, i
       v16 = v13 << 12;
       *v15 = (16 * ((v13 << 24) & 0xF000000)) | ((v13 << 24) & 0xF000000) | (16 * (v16 & 0xF0000)) | (v16 & 0xF0000) | (16 * (v13 & 0xF00)) | (v13 & 0xF00) | (16 * ((uint16_t)v13 >> 12)) | ((uint16_t)v13 >> 12);
       ++v15;
-      v17 = m64p_swap32(*v12);
+      v17 = bswap32(*v12);
       v6 = v12 + 1;
       v18 = v17;
       v19 = (16 * ((v17 >> 16) & 0xF00)) | ((v17 >> 16) & 0xF00) | (16 * (v17 >> 28)) | (v17 >> 28);
@@ -554,14 +554,14 @@ static INLINE void load4bI(uint8_t *src, uint8_t *dst, int wid_64, int height, i
     do
     {
       v24 = v23;
-      v25 = m64p_swap32(v21[1]);
+      v25 = bswap32(v21[1]);
       v26 = v25 >> 4;
       *v22 = (16 * ((v25 << 8) & 0xF000000)) | ((v25 << 8) & 0xF000000) | (16 * (v26 & 0xF0000)) | (v26 & 0xF0000) | (16 * ((v25 >> 16) & 0xF00)) | ((v25 >> 16) & 0xF00) | (16 * (v25 >> 28)) | (v25 >> 28);
       v27 = v22 + 1;
       v28 = v25 << 12;
       *v27 = (16 * ((v25 << 24) & 0xF000000)) | ((v25 << 24) & 0xF000000) | (16 * (v28 & 0xF0000)) | (v28 & 0xF0000) | (16 * (v25 & 0xF00)) | (v25 & 0xF00) | (16 * ((uint16_t)v25 >> 12)) | ((uint16_t)v25 >> 12);
       ++v27;
-      v29 = m64p_swap32(*v21);
+      v29 = bswap32(*v21);
       v21 += 2;
       v30 = v29;
       v31 = (16 * ((v29 >> 16) & 0xF00)) | ((v29 >> 16) & 0xF00) | (16 * (v29 >> 28)) | (v29 >> 28);

--- a/glide2gl/src/Glide64/TexLoad8b.h
+++ b/glide2gl/src/Glide64/TexLoad8b.h
@@ -70,7 +70,7 @@ static INLINE void load8bCI(uint8_t *src, uint8_t *dst, int wid_64, int height, 
     do
     {
       v11 = v10;
-      v12 = m64p_swap32(*(uint32_t *)v7);
+      v12 = bswap32(*(uint32_t *)v7);
       v13 = (uint32_t *)(v7 + 4);
       ALOWORD(v10) = __ROR16(*(uint16_t *)((char *)pal + ((v12 >> 15) & 0x1FE)), 1, NBITS_8B);
       v14 = v10 << 16;
@@ -82,7 +82,7 @@ static INLINE void load8bCI(uint8_t *src, uint8_t *dst, int wid_64, int height, 
       ALOWORD(v14) = __ROR16(*(uint16_t *)((char *)pal + ((v12 >> 7) & 0x1FE)), 1, NBITS_8B);
       *v15 = v14;
       ++v15;
-      v16 = m64p_swap32(*v13);
+      v16 = bswap32(*v13);
       v7 = (uint8_t *)(v13 + 1);
       ALOWORD(v14) = __ROR16(*(uint16_t *)((char *)pal + ((v16 >> 15) & 0x1FE)), 1, NBITS_8B);
       v14 <<= 16;
@@ -106,7 +106,7 @@ static INLINE void load8bCI(uint8_t *src, uint8_t *dst, int wid_64, int height, 
     do
     {
       v20 = v19;
-      v21 = m64p_swap32(v17[1]);
+      v21 = bswap32(v17[1]);
       ALOWORD(v19) = __ROR16(*(uint16_t *)((char *)pal + ((v21 >> 15) & 0x1FE)), 1, NBITS_8B);
       v22 = v19 << 16;
       ALOWORD(v22) = __ROR16(*(uint16_t *)((char *)pal + ((v21 >> 23) & 0x1FE)), 1, NBITS_8B);
@@ -117,7 +117,7 @@ static INLINE void load8bCI(uint8_t *src, uint8_t *dst, int wid_64, int height, 
       ALOWORD(v22) = __ROR16(*(uint16_t *)((char *)pal + ((v21 >> 7) & 0x1FE)), 1, NBITS_8B);
       *v23 = v22;
       ++v23;
-      v24 = m64p_swap32(*v17);
+      v24 = bswap32(*v17);
       v17 = (uint32_t *)&src[((uintptr_t)v17 + 8 - (uintptr_t)src) & 0x7FF];
       ALOWORD(v22) = __ROR16(*(uint16_t *)((char *)pal + ((v24 >> 15) & 0x1FE)), 1, NBITS_8B);
       v22 <<= 16;
@@ -169,7 +169,7 @@ static INLINE void load8bIA8(uint8_t *src, uint8_t *dst, int wid_64, int height,
     do
     {
       v11 = v10;
-      v12 = m64p_swap32(*v7);
+      v12 = bswap32(*v7);
       v13 = v7 + 1;
       ALOWORD(v10) = __ROR16(*(uint16_t *)((char *)pal + ((v12 >> 15) & 0x1FE)), 8, NBITS_8B);
       v14 = v10 << 16;
@@ -181,7 +181,7 @@ static INLINE void load8bIA8(uint8_t *src, uint8_t *dst, int wid_64, int height,
       ALOWORD(v14) = __ROR16(*(uint16_t *)((char *)pal + ((v12 >> 7) & 0x1FE)), 8, NBITS_8B);
       *v15 = v14;
       ++v15;
-      v16 = m64p_swap32(*v13);
+      v16 = bswap32(*v13);
       v7 = v13 + 1;
       ALOWORD(v14) = __ROR16(*(uint16_t *)((char *)pal + ((v16 >> 15) & 0x1FE)), 8, NBITS_8B);
       v14 <<= 16;
@@ -205,7 +205,7 @@ static INLINE void load8bIA8(uint8_t *src, uint8_t *dst, int wid_64, int height,
     do
     {
       v20 = v19;
-      v21 = m64p_swap32(v17[1]);
+      v21 = bswap32(v17[1]);
       ALOWORD(v19) = __ROR16(*(uint16_t *)((char *)pal + ((v21 >> 15) & 0x1FE)), 8, NBITS_8B);
       v22 = v19 << 16;
       ALOWORD(v22) = __ROR16(*(uint16_t *)((char *)pal + ((v21 >> 23) & 0x1FE)), 8, NBITS_8B);
@@ -216,7 +216,7 @@ static INLINE void load8bIA8(uint8_t *src, uint8_t *dst, int wid_64, int height,
       ALOWORD(v22) = __ROR16(*(uint16_t *)((char *)pal + ((v21 >> 7) & 0x1FE)), 8, NBITS_8B);
       *v23 = v22;
       ++v23;
-      v24 = m64p_swap32(*v17);
+      v24 = bswap32(*v17);
       v17 += 2;
       ALOWORD(v22) = __ROR16(*(uint16_t *)((char *)pal + ((v24 >> 15) & 0x1FE)), 8, NBITS_8B);
       v22 <<= 16;

--- a/glide2gl/src/Glide64/Util.h
+++ b/glide2gl/src/Glide64/Util.h
@@ -40,8 +40,6 @@
 #ifndef Util_H
 #define Util_H
 
-#include "../../../mupen64plus-core/src/main/util.h"
-
 #define NOT_TMU0	0x00
 #define NOT_TMU1	0x01
 #define NOT_TMU2	0x02
@@ -54,6 +52,20 @@ void update(void);
 void update_scissor(bool set_scissor);
 
 float ScaleZ(float z);
+
+#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
+#include <stdlib.h>
+#define bswap32(x) _byteswap_ulong(x)
+#else
+static inline uint32_t bswap32(uint32_t val)
+{
+   return (((val & 0xff000000) >> 24) |
+         ((val & 0x00ff0000) >>  8) |
+         ((val & 0x0000ff00) <<  8) |
+         ((val & 0x000000ff) << 24));
+
+}
+#endif
 
 #define ALOWORD(x)   (*((uint16_t*)&x))   // low word
 

--- a/glide2gl/src/Glide64/glide64_gDP.h
+++ b/glide2gl/src/Glide64/glide64_gDP.h
@@ -49,15 +49,15 @@ static INLINE void loadBlock(uint32_t *src, uint32_t *dst, uint32_t off, int dxt
       {
          *v5++ = __ROL__(v10, 8, nbits);
       }while (--v9);
-      *v5++ = m64p_swap32(*v7++);
+      *v5++ = bswap32(*v7++);
       v6 = cnt - 1;
       if ( cnt != 1 )
       {
 LABEL_23:
          do
          {
-            *v5++ = m64p_swap32(*v7++);
-            *v5++ = m64p_swap32(*v7++);
+            *v5++ = bswap32(*v7++);
+            *v5++ = bswap32(*v7++);
          }while (--v6 );
       }
       v13 = off & 3;

--- a/glide2gl/src/Glide64/glide64_rdp.c
+++ b/glide2gl/src/Glide64/glide64_rdp.c
@@ -1232,7 +1232,7 @@ static INLINE void loadTile(uint32_t *src, uint32_t *dst,
          while ( v15 );
          v18 = *v17;
          v13 = v17 + 1;
-         *v7 = m64p_swap32(v18);
+         *v7 = bswap32(v18);
          ++v7;
          --v8;
          if ( v8 )
@@ -1240,8 +1240,8 @@ static INLINE void loadTile(uint32_t *src, uint32_t *dst,
 LABEL_20:
             do
             {
-               *v7 = m64p_swap32(*v13);
-               v7[1] = m64p_swap32(v13[1]);
+               *v7 = bswap32(*v13);
+               v7[1] = bswap32(v13[1]);
                v13 += 2;
                v7 += 2;
                --v8;
@@ -2428,7 +2428,6 @@ static void lle_triangle(uint32_t w0, uint32_t w1, int shade, int texture, int z
 
    nbVtxs = 0;
    vtx = (VERTEX*)&vtxbuf[nbVtxs++];
-   memset(vtxbuf, 0, sizeof(vtxbuf));
 
    xleft      = xm;
    xright     = xh;

--- a/glide2gl/src/Glitch64/glitch64_textures.c
+++ b/glide2gl/src/Glitch64/glitch64_textures.c
@@ -70,12 +70,7 @@ static void remove_tex(unsigned int idmin, unsigned int idmax)
    unsigned int n = 0;
    texlist *current, *tmp;
 
-   unsigned count = HASH_COUNT(list);
-
-   if (!count)
-       return;
-
-   t = (GLuint*)malloc(count * sizeof(GLuint));
+   t = (GLuint*)malloc(HASH_COUNT(list) * sizeof(GLuint));
    HASH_ITER(hh, list, current, tmp)
    {
       if (current->id >= idmin && current->id < idmax)

--- a/glide2gl/src/Glitch64/glitchmain.c
+++ b/glide2gl/src/Glitch64/glitchmain.c
@@ -33,14 +33,14 @@ extern retro_environment_t environ_cb;
 
 int width, height;
 int bgra8888_support;
-static int npot_support;
+int npot_support;
 // ZIGGY
 static GLuint default_texture;
 int glsl_support = 1;
 //Gonetz
 
-static uint16_t *frameBuffer;
-static uint8_t  *buf;
+uint16_t *frameBuffer;
+uint8_t  *buf;
 
 #ifdef EMSCRIPTEN
 GLuint glitch_vbo;

--- a/mupen64plus-core/src/main/util.h
+++ b/mupen64plus-core/src/main/util.h
@@ -37,22 +37,14 @@ extern "C" {
 #include <stdlib.h>
 #endif
 
-#if defined(__llvm__) || (defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__) >= 403)
-#define BUILTIN_BSWAP16 __builtin_bswap16
-#define BUILTIN_BSWAP32 __builtin_bswap32
-#define BUILTIN_BSWAP64 __builtin_bswap64
-#else
-#if defined(_MSC_VER)
-#define BUILTIN_BSWAP16 _byteswap_ushort
-#define BUILTIN_BSWAP32 _byteswap_ulong
-#define BUILTIN_BSWAP64 _byteswap_uint64
-#endif
-#endif
+/* GCC has also byte swap intrinsics (__builtin_bswap32, etc.), but they were
+ * added in relatively recent versions. In addition, GCC can detect the byte
+ * swap code and optimize it with a high enough optimization level. */
 
 static osal_inline unsigned short m64p_swap16(unsigned short x)
 {
-    #ifdef BUILTIN_BSWAP16
-    return BUILTIN_BSWAP16(x);
+    #ifdef _MSC_VER
+    return _byteswap_ushort(x);
     #else
     return ((x & 0x00FF) << 8) |
            ((x & 0xFF00) >> 8);
@@ -61,8 +53,8 @@ static osal_inline unsigned short m64p_swap16(unsigned short x)
 
 static osal_inline unsigned int m64p_swap32(unsigned int x)
 {
-    #ifdef BUILTIN_BSWAP32
-    return BUILTIN_BSWAP32(x); // long is always 32-bit in Windows
+    #ifdef _MSC_VER
+    return _byteswap_ulong(x); // long is always 32-bit in Windows
     #else
     return ((x & 0x000000FF) << 24) |
            ((x & 0x0000FF00) << 8) |
@@ -73,8 +65,8 @@ static osal_inline unsigned int m64p_swap32(unsigned int x)
 
 static osal_inline unsigned long long int m64p_swap64(unsigned long long int x)
 {
-    #ifdef BUILTIN_BSWAP64
-    return BUILTIN_BSWAP64(x);
+    #ifdef _MSC_VER
+    return _byteswap_uint64(x);
     #else
     return ((x & 0x00000000000000FFULL) << 56) |
            ((x & 0x000000000000FF00ULL) << 40) |


### PR DESCRIPTION
Reverts libretro/mupen64plus-libretro#213

Caused a segfault in Tsumi to Batsu (Sin and Punishment). Please regression test this and only send a new PR when it's fixed.
