### PR TITLE
Only use GCC builtins on GCC >= 4.8 for now

### DIFF
--- a/mupen64plus-core/src/main/util.h
+++ b/mupen64plus-core/src/main/util.h
@@ -37,7 +37,7 @@ extern "C" {
 #include <stdlib.h>
 #endif
 
-#if defined(__llvm__) || (defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__) >= 403)
+#if defined(__llvm__) || (defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__) >= 408)
 #define BUILTIN_BSWAP16 __builtin_bswap16
 #define BUILTIN_BSWAP32 __builtin_bswap32
 #define BUILTIN_BSWAP64 __builtin_bswap64


### PR DESCRIPTION
There have been some unofficial reports of mupen not compiling/crashing in some systems so I'll apply the same solution as suggested in https://github.com/libretro/RetroArch/commit/417d26ed02f5b6b59aab756db472dc76ce22bc39 for now.
