### PR TITLE
Memory fixes

### DIFF
--- a/glide2gl/src/Glide64/Glide64_Ini.c
+++ b/glide2gl/src/Glide64/Glide64_Ini.c
@@ -1925,4 +1925,8 @@ void ReadSpecialSettings (const char * name)
 	  else if (strcmp(var.value, "bilinear") == 0)
 		 glide_set_filtering(3);
    }
+
+   /* this has to be done here. */
+   if (strstr(name, "POKEMON STADIUM 2"))
+      settings.frame_buffer &= ~fb_emulation;
 }

--- a/glide2gl/src/Glide64/glide64_rdp.c
+++ b/glide2gl/src/Glide64/glide64_rdp.c
@@ -210,14 +210,10 @@ void rdp_new(void)
 {
    unsigned i, cpu;
    cpu = 0;
-   rdp.vtx1 = (VERTEX*)malloc(256 * sizeof(VERTEX));
-   rdp.vtx2 = (VERTEX*)malloc(256 * sizeof(VERTEX));
-   rdp.vtx  = (VERTEX*)malloc(MAX_VTX * sizeof(VERTEX));
-   rdp.frame_buffers = (COLOR_IMAGE*)malloc((NUMTEXBUF+2) * sizeof(COLOR_IMAGE));
-
-   memset(rdp.vtx1, 0, 256 * sizeof(VERTEX));
-   memset(rdp.vtx2, 0, 256 * sizeof(VERTEX));
-   memset(rdp.vtx,  0, MAX_VTX * sizeof(VERTEX));
+   rdp.vtx1 = (VERTEX*)calloc(256, sizeof(VERTEX));
+   rdp.vtx2 = (VERTEX*)calloc(256, sizeof(VERTEX));
+   rdp.vtx  = (VERTEX*)calloc(MAX_VTX, sizeof(VERTEX));
+   rdp.frame_buffers = (COLOR_IMAGE*)calloc(NUMTEXBUF+2, sizeof(COLOR_IMAGE));
 
    rdp.vtxbuf = 0;
    rdp.vtxbuf2 = 0;
@@ -226,7 +222,7 @@ void rdp_new(void)
 
    for (i = 0; i < MAX_TMU; i++)
    {
-      rdp.cache[i] = (CACHE_LUT*)malloc(MAX_CACHE * sizeof(CACHE_LUT));
+      rdp.cache[i] = (CACHE_LUT*)calloc(MAX_CACHE, sizeof(CACHE_LUT));
       rdp.cur_cache[i]   = 0;
    }
 

--- a/libretro/brumme_crc.c
+++ b/libretro/brumme_crc.c
@@ -106,7 +106,8 @@ void CRC_BuildTable(void)
    }
 
    for (slice = 1; slice < MaxSlice; slice++)
-     Crc32Lookup[slice][i] = (Crc32Lookup[slice - 1][i] >> 8) ^ Crc32Lookup[0][Crc32Lookup[slice - 1][i] & 0xFF];
+      for (i = 0; i <= 0xFF; i++)
+         Crc32Lookup[slice][i] = (Crc32Lookup[slice - 1][i] >> 8) ^ Crc32Lookup[0][Crc32Lookup[slice - 1][i] & 0xFF];
 }
 
 unsigned int CRC32(unsigned int crc, void *buffer, unsigned int count)


### PR DESCRIPTION
This fixes a buffer overflow in the CRC32 code, reads of uninitialized memory and the crash #118.

Graphical issues like the ones bellow are to be expected.
![https://i.imgur.com/gJGCoHj.png](https://i.imgur.com/gJGCoHj.png)
