### PR TITLE
fix L- and Z-trigger lockout with C-button mode

### DIFF
--- a/mupen64plus-core/src/plugin/emulate_game_controller_via_libretro.c
+++ b/mupen64plus-core/src/plugin/emulate_game_controller_via_libretro.c
@@ -723,6 +723,8 @@ static void inputGetKeys_default( int Control, BUTTONS *Keys )
       Keys->L_CBUTTON = input_cb(Control, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y);
       Keys->D_CBUTTON = input_cb(Control, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B);
       Keys->U_CBUTTON = input_cb(Control, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X);
+      Keys->L_TRIG = input_cb(Control, RETRO_DEVICE_JOYPAD, 0,   RETRO_DEVICE_ID_JOYPAD_L);
+      Keys->Z_TRIG = input_cb(Control, RETRO_DEVICE_JOYPAD, 0,   RETRO_DEVICE_ID_JOYPAD_L2);
    }
    else
    {


### PR DESCRIPTION
I tested this briefly but more testing would be good, if possible. This change was needed to make the N64 overlay work correctly but it can be tested with any gamepad/kbd. Just hold R2 and it normally disables L1 and L2. With this change, they still work.
