### PR TITLE
sync to upstream changes for typo in SDV

### DIFF
--- a/mupen64plus-rsp-cxd4/su.h
+++ b/mupen64plus-rsp-cxd4/su.h
@@ -608,7 +608,7 @@ static void SDV(int vt, int element, int offset, int base)
         register int i;
 
         for (i = 0; i < 8; i++)
-            RSP.DMEM[BES(addr &= 0x00000FFF)] = VR_B(vt, (e+i)&0xF);
+            RSP.DMEM[BES(addr++ & 0x00000FFF)] = VR_B(vt, (e+i)&0xF);
         return;
     }
     switch (addr & 07)


### PR DESCRIPTION
Due to said typo from many years ago, this loop was clearly broken.

It needs to cover a ranged span of bytes, not redundantly overwrite the same byte 7 times.

I doubt that this will be used in any games to make a noticeable fix.
