### PR TITLE
default to cached_interpreter instead of dynarec

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -205,7 +205,7 @@ static void setup_variables(void)
    struct retro_variable variables[] = {
       { "mupen64-cpucore",
 #ifdef DYNAREC
-         "CPU Core; dynamic_recompiler|cached_interpreter|pure_interpreter" },
+         "CPU Core; cached_interpreter|pure_interpreter|dynamic_recompiler" },
 #else
          "CPU Core; cached_interpreter|pure_interpreter" },
 #endif


### PR DESCRIPTION
This is currently a showstopper for the iOS crowd.
