### PR TITLE
[gles2N64] Fix 2 compile warnings from unused fgets() return result.

### DIFF
--- a/gles2n64/src/glN64Config.c
+++ b/gles2n64/src/glN64Config.c
@@ -196,7 +196,7 @@ void Config_gln64_LoadRomConfig(unsigned char* header)
          log_cb(RETRO_LOG_INFO, "[gles2N64]: Searching Database for \"%s\" ROM\n", config.romName);
       while (!feof(f))
       {
-         if (fgets(line, 4096, f) == NULL)
+         if (fgets(line, sizeof(line), f) == NULL)
             fputs("glN64 ROM config stream read error.\n", stderr);
          if (line[0] == '\n') continue;
 
@@ -264,7 +264,7 @@ void Config_gln64_LoadConfig(void)
       {
          char *val;
 
-         if (fgets(line, 4096, f) == NULL)
+         if (fgets(line, sizeof(line), f) == NULL)
             fputs("glN64 config stream read error.\n", stderr);
 
          if (line[0] == '#' || line[0] == '\n')

--- a/gles2n64/src/glN64Config.c
+++ b/gles2n64/src/glN64Config.c
@@ -196,7 +196,8 @@ void Config_gln64_LoadRomConfig(unsigned char* header)
          log_cb(RETRO_LOG_INFO, "[gles2N64]: Searching Database for \"%s\" ROM\n", config.romName);
       while (!feof(f))
       {
-         fgets(line, 4096, f);
+         if (fgets(line, 4096, f) == NULL)
+            fputs("glN64 ROM config stream read error.\n", stderr);
          if (line[0] == '\n') continue;
 
          if (strncmp(line,"rom name=", 9) == 0)
@@ -262,7 +263,9 @@ void Config_gln64_LoadConfig(void)
       while (!feof( f ))
       {
          char *val;
-         fgets( line, 4096, f );
+
+         if (fgets(line, 4096, f) == NULL)
+            fputs("glN64 config stream read error.\n", stderr);
 
          if (line[0] == '#' || line[0] == '\n')
             continue;


### PR DESCRIPTION
Alright, sorry about the long while no updates.

I had recently started compiling this libretro core again and noticed no warnings at all except only for these two, on 32-bit Linux:

```
gles2n64/src/glN64Config.c: In function ‘Config_gln64_LoadRomConfig’:
gles2n64/src/glN64Config.c:199:15: warning: ignoring return value of ‘fgets’, declared with attribute warn_unused_result [-Wunused-result]
          fgets(line, 4096, f);
               ^
gles2n64/src/glN64Config.c: In function ‘Config_gln64_LoadConfig’:
gles2n64/src/glN64Config.c:265:15: warning: ignoring return value of ‘fgets’, declared with attribute warn_unused_result [-Wunused-result]
          fgets( line, 4096, f );
```

So, I figured, why not fix the warnings so that the entire compilation is now warning-free?

In the process, the "unused return result" is now used to diagnose any unexpected failure from the call to C standard library `fgets`, so this is more secure just in case.
