### PR TITLE
Backport https://github.com/cxd4/rsp/commit/9cf9089a51641dca6902dd72c1c141b2be03e77b

### DIFF
--- a/mupen64plus-rsp-cxd4-new/su.c
+++ b/mupen64plus-rsp-cxd4-new/su.c
@@ -229,6 +229,7 @@ MT_CMD_CLOCK       ,MT_READ_ONLY       ,MT_READ_ONLY       ,MT_READ_ONLY
 
 void SP_DMA_READ(void)
 {
+    unsigned int offC, offD; /* SP cache and dynamic DMA pointers */
     register unsigned int length;
     register unsigned int count;
     register unsigned int skip;
@@ -244,7 +245,6 @@ void SP_DMA_READ(void)
     skip += length;
     do
     { /* `count` always starts > 0, so we begin with `do` instead of `while`. */
-        unsigned int offC, offD; /* SP cache and dynamic DMA pointers */
         register unsigned int i = 0;
 
         --count;
@@ -259,12 +259,16 @@ void SP_DMA_READ(void)
             i += 0x008;
         } while (i < length);
     } while (count);
+
+    if ((*CR[0x0] & 0x1000) ^ (offC & 0x1000))
+        message("DMA over the DMEM-to-IMEM gap.");
     GET_RCP_REG(SP_DMA_BUSY_REG)  =  0x00000000;
     GET_RCP_REG(SP_STATUS_REG)   &= ~SP_STATUS_DMA_BUSY;
     return;
 }
 void SP_DMA_WRITE(void)
 {
+    unsigned int offC, offD; /* SP cache and dynamic DMA pointers */
     register unsigned int length;
     register unsigned int count;
     register unsigned int skip;
@@ -281,7 +285,6 @@ void SP_DMA_WRITE(void)
     skip += length;
     do
     { /* `count` always starts > 0, so we begin with `do` instead of `while`. */
-        unsigned int offC, offD; /* SP cache and dynamic DMA pointers */
         register unsigned int i = 0;
 
         --count;
@@ -293,6 +296,9 @@ void SP_DMA_WRITE(void)
             i += 0x000008;
         } while (i < length);
     } while (count);
+
+    if ((*CR[0x0] & 0x1000) ^ (offC & 0x1000))
+        message("DMA over the DMEM-to-IMEM gap.");
     GET_RCP_REG(SP_DMA_BUSY_REG)  =  0x00000000;
     GET_RCP_REG(SP_STATUS_REG)   &= ~SP_STATUS_DMA_BUSY;
     return;

--- a/mupen64plus-rsp-cxd4/rsp.c
+++ b/mupen64plus-rsp-cxd4/rsp.c
@@ -640,8 +640,6 @@ EXPORT void CALL cxd4InitiateRSP(RSP_INFO Rsp_Info, unsigned int *CycleCount)
 
     if (Rsp_Info.DMEM == Rsp_Info.IMEM) /* usually dummy RSP data for testing */
         return; /* DMA is not executed just because plugin initiates. */
-    while (Rsp_Info.IMEM != Rsp_Info.DMEM + 4096)
-        message("Virtual host map noncontiguity.", 3);
 
     RSP = Rsp_Info;
     *RSP.SP_PC_REG = 0x04001000 & 0x00000FFF; /* task init bug on Mupen64 */

--- a/mupen64plus-rsp-cxd4/su.h
+++ b/mupen64plus-rsp-cxd4/su.h
@@ -138,6 +138,8 @@ static void MT_DMA_DRAM(int rt)
 }
 static void MT_DMA_READ_LENGTH(int rt)
 {
+    unsigned int offC, offD; /* SP cache and dynamic DMA pointers */
+
     *RSP.SP_RD_LEN_REG = SR[rt] | 07;
     {
        unsigned int length = (*RSP.SP_RD_LEN_REG & 0x00000FFF) >>  0;
@@ -149,7 +151,6 @@ static void MT_DMA_READ_LENGTH(int rt)
        skip += length;
        do
        { /* `count` always starts > 0, so we begin with `do` instead of `while`. */
-          unsigned int offC, offD; /* SP cache and dynamic DMA pointers */
           register unsigned int i = 0;
 
           --count;
@@ -165,12 +166,16 @@ static void MT_DMA_READ_LENGTH(int rt)
           } while (i < length);
        } while (count);
 
+       if ((offC & 0x1000) ^ (*RSP.SP_MEM_ADDR_REG & 0x1000))
+	  message("DMA over the DMEM-to-IMEM gap.", 3);
        *RSP.SP_DMA_BUSY_REG = 0x00000000;
        *RSP.SP_STATUS_REG &= ~SP_STATUS_DMA_BUSY;
     }
 }
 static void MT_DMA_WRITE_LENGTH(int rt)
 {
+    unsigned int offC, offD; /* SP cache and dynamic DMA pointers */
+
     *RSP.SP_WR_LEN_REG = SR[rt] | 07;
     {
        unsigned int length = (*RSP.SP_WR_LEN_REG & 0x00000FFF) >>  0;
@@ -182,7 +187,6 @@ static void MT_DMA_WRITE_LENGTH(int rt)
        skip += length;
        do
        { /* `count` always starts > 0, so we begin with `do` instead of `while`. */
-          unsigned int offC, offD; /* SP cache and dynamic DMA pointers */
           register unsigned int i = 0;
 
           --count;
@@ -194,6 +198,9 @@ static void MT_DMA_WRITE_LENGTH(int rt)
              i += 0x000008;
           } while (i < length);
        } while (count);
+
+       if ((offC & 0x1000) ^ (*RSP.SP_MEM_ADDR_REG & 0x1000))
+	  message("DMA over the DMEM-to-IMEM gap.", 3);
        *RSP.SP_DMA_BUSY_REG = 0x00000000;
        *RSP.SP_STATUS_REG &= ~SP_STATUS_DMA_BUSY;
     }


### PR DESCRIPTION
Historically I had the "Virtual host map noncontiguity." error message to indicate an inaccurate (and likely hazard-prone) relation between where DMEM and IMEM are allocated in the RCP memory map.  (They should be exactly 4,096 bytes apart.)

I recently have found that sometimes when the plugin info struct is passed down to the "plugin", it is possible for the addresses to be skewed even if they originally satisfied the above condition.  In observing that, I see fit to totally remove the requirement altogether from the RSP.  The only time it should really matter is if SP DMA tries to read/write in between DMEM and IMEM in the same command, which starting now we have an error message for, for diagnostic purposes.  (Though I don't think anybody will run in to it.)

Did not know which folder to backport to (cxd4 or cxd4-new), so I figured why not both.
