### PR TITLE
Change stencil to false.

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -883,7 +883,7 @@ bool retro_load_game(const struct retro_game_info *game)
       params.context_reset         = context_reset;
       params.context_destroy       = context_destroy;
       params.environ_cb            = environ_cb;
-      params.stencil               = true;
+      params.stencil               = false;
 
 #if 0
       if (gfx_plugin == GFX_GLIDE64)


### PR DESCRIPTION
I have to admit, I don't know the full ramifications of this change, but because OES_packed_depth_stencil doesn't exist on the Rpi3, and this variable is set to true, this core
won't start on the rpi3. This change allows the core to start.
This fixes https://github.com/libretro/mupen64plus-libretro/issues/320
