### PR TITLE
Sign extend the immediate field in SLTIU

### DIFF
--- a/mupen64plus-rsp-cxd4-new/su.c
+++ b/mupen64plus-rsp-cxd4-new/su.c
@@ -1780,7 +1780,7 @@ EX:
         case 013: /* SLTIU */
             rs = (inst >> 21) & 31;
             rt = (inst >> 16) & 31;
-            SR[rt] = ((u32)(SR[rs]) < (u16)(inst));
+            SR[rt] = ((u32)(SR[rs]) < (u32)(s16)(inst));
             SR[0] = 0x00000000;
             CONTINUE;
         case 014: /* ANDI */


### PR DESCRIPTION
Every doc I've read, stated that the immediate field is sign extended.
