### PR TITLE
re-translated old SLTIU refactoring from August 2013

### DIFF
--- a/mupen64plus-rsp-cxd4/rsp.c
+++ b/mupen64plus-rsp-cxd4/rsp.c
@@ -233,7 +233,7 @@ static unsigned int run_task_opcode(uint32_t inst, const int opcode)
       case 013: /* SLTIU */
          rs = (inst >> 21) & 31;
          rt = (inst >> 16) & 31;
-         SR[rt] = ((unsigned)(SR[rs]) < (unsigned short)(inst));
+         SR[rt] = ((unsigned)(SR[rs]) < (unsigned)(short)(inst));
          SR[0] = 0x00000000;
          break;
       case 014: /* ANDI */


### PR DESCRIPTION
https://github.com/libretro/mupen64plus-libretro/pull/346

It applies to this time the older RSP codebase currently in use by the RetroArch core.
