### PR TITLE
Simplify the build system command-line output.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -140,7 +140,7 @@ ifeq ($(WITH_DYNAREC), arm)
 endif
 ifeq ($(WITH_DYNAREC), $(filter $(WITH_DYNAREC), i386 i686 x86 x86_64 x64))
 		DYNAREC_USED = 1
-		CPUFLAGS += -msse -msse2 -DUSE_SSE_SUPPORT
+		CPUFLAGS += -msse2 -DUSE_SSE_SUPPORT
 		SOURCES_C += $(CORE_DIR)/src/r4300/hacktarux_dynarec/assemble.c \
 						 $(CORE_DIR)/src/r4300/hacktarux_dynarec/gbc.c \
 						 $(CORE_DIR)/src/r4300/hacktarux_dynarec/gtlb.c \

--- a/Makefile.common
+++ b/Makefile.common
@@ -140,7 +140,7 @@ ifeq ($(WITH_DYNAREC), arm)
 endif
 ifeq ($(WITH_DYNAREC), $(filter $(WITH_DYNAREC), i386 i686 x86 x86_64 x64))
 		DYNAREC_USED = 1
-		CPUFLAGS += -msse -msse2 -DUSE_MMX_DECODES -DUSE_SSE_SUPPORT
+		CPUFLAGS += -msse -msse2 -DUSE_SSE_SUPPORT
 		SOURCES_C += $(CORE_DIR)/src/r4300/hacktarux_dynarec/assemble.c \
 						 $(CORE_DIR)/src/r4300/hacktarux_dynarec/gbc.c \
 						 $(CORE_DIR)/src/r4300/hacktarux_dynarec/gtlb.c \


### PR DESCRIPTION
This, I could have contributed like last year, but didn't really think much of its significance.

Overtime, though, I always see the added command-line flood to the compile output.

We can remove `-msse` and `-DUSE_MMX_DECODES` from Makefile.common:
- `USE_MMX_DECODES` is only pertinent to my SSE and MMX fork of angrylion's RDP.  I had arranged the headers to have this macro pre-defined under the condition that `USE_SSE_SUPPORT` is defined, which the Makefile already does.
- `-msse` is unnecessary re-specification if you have also passed `-msse2`.  The SSE instruction set is a subset encompassed by the SSE2 instruction set level.  `-msse2 -msse` is equivalent to just `-msse2`.

The shortened compile output text in my console buffer I have to scroll through seems worth it.
