### PR TITLE
Use unsigned int for internal cheat format.  Fixes cheats on 32-bit

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1529,7 +1529,7 @@ void retro_cheat_set(unsigned index, bool enabled, const char* codeLine)
 	char name[256];
 	m64p_cheat_code mupenCode[256];
 	int matchLength=0,partCount=0;
-	int codeParts[256];
+	unsigned int codeParts[256];
 	int cursor;
 	
 	//Generate a name
@@ -1545,7 +1545,7 @@ void retro_cheat_set(unsigned index, bool enabled, const char* codeLine)
 				char codePartS[matchLength];
 				strncpy(codePartS,codeLine+cursor-matchLength,matchLength);
 				codePartS[matchLength]=0;
-				codeParts[partCount++]=strtol(codePartS,NULL,16);
+				codeParts[partCount++]=strtoul(codePartS,NULL,16);
 				matchLength=0;
 			}
 		}


### PR DESCRIPTION
I did a dumb and used signed ints for storing the result of a str to int conversion of cheat codes.  Given most cheats have an address portion along the lines of 80E412C6, this resulted in the internal cheat code address instead being set to 7FFFFFFF, and not functioning.  Using unsigned ints fixes this issue.