### PR TITLE
Revert "Better error handling"

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1207,9 +1207,6 @@ static bool retro_load_game_gl(const struct retro_game_info *game)
 
 bool retro_load_game(const struct retro_game_info *game)
 {
-   if (!game)
-      return false;
-
    format_saved_memory();
 
    update_variables(true);


### PR DESCRIPTION
This reverts commit 105f188ed1c3f1cb2c2dc684c74b10a7403c42ca.

This should no longer be needed thanks to Alcaro, see here. https://github.com/libretro/RetroArch/issues/4493#issuecomment-274963520

mupen64plus also segfaults with or without this commit unfortunately, see here. https://github.com/libretro/mupen64plus-libretro/issues/424