### PR TITLE
Remove -g from non-debug builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -425,7 +425,7 @@ ifeq ($(DEBUG), 1)
    CPUOPTS += -O0 -g
    CPUOPTS += -DOPENGL_DEBUG
 else
-	CPUOPTS += -O2 -g -DNDEBUG
+   CPUOPTS += -O2 -DNDEBUG
 endif
 
 ifeq ($(platform), qnx)


### PR DESCRIPTION
-g is only needed for debug builds so lets remove it from non-debug builds.