### PR TITLE
Raspberry Pi: use new vendor library names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ ifneq (,$(findstring unix,$(platform)))
       ifneq (,$(findstring mesa,$(platform)))
          GL_LIB := -lGLESv2
       else
-         GL_LIB := -L/opt/vc/lib -lGLESv2
+         GL_LIB := -L/opt/vc/lib -lbrcmGLESv2
          INCFLAGS += -I/opt/vc/include -I/opt/vc/include/interface/vcos -I/opt/vc/include/interface/vcos/pthreads
       endif
       


### PR DESCRIPTION
Needed for new firmwares on Raspbian stretch and SDL 2.0.6.