### PR TITLE
Get it building on Emscripten

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -719,8 +719,8 @@ endif
 
 COREFLAGS += -D__LIBRETRO__ -DM64P_PLUGIN_API -DM64P_CORE_PROTOTYPES -D_ENDUSER_RELEASE -DSINC_LOWER_QUALITY
 
-OBJOUT   = -o
-LINKOUT  = -o
+OBJOUT   = -o $(shell)
+LINKOUT  = -o $(shell)
 
 ifneq (,$(findstring msvc,$(platform)))
 	OBJOUT = -Fo

--- a/Makefile
+++ b/Makefile
@@ -131,14 +131,14 @@ ifneq (,$(findstring unix,$(platform)))
    # Raspberry Pi
    ifneq (,$(findstring rpi,$(platform)))
       GLES = 1
-      
+
       ifneq (,$(findstring mesa,$(platform)))
          GL_LIB := -lGLESv2
       else
          GL_LIB := -L/opt/vc/lib -lGLESv2
          INCFLAGS += -I/opt/vc/include -I/opt/vc/include/interface/vcos -I/opt/vc/include/interface/vcos/pthreads
       endif
-      
+
       WITH_DYNAREC=arm
       ifneq (,$(findstring rpi2,$(platform)))
          CPUFLAGS += -DNO_ASM -DARM -D__arm__ -DARM_ASM -D__NEON_OPT -DNOSSE
@@ -333,40 +333,17 @@ else ifeq ($(platform), emscripten)
    GLES := 1
    WITH_DYNAREC :=
 
-   HAVE_PARALLEL=0
+   HAVE_PARALLEL = 0
    CPUFLAGS += -DNOSSE
    CPUFLAGS += -DEMSCRIPTEN -DNO_ASM -s USE_ZLIB=1
-   PLATCFLAGS += \
-      -Dsinc_resampler=mupen_sinc_resampler \
-      -DCC_resampler=mupen_CC_resampler \
-      -Drglgen_symbol_map=mupen_rglgen_symbol_map \
-      -Drglgen_resolve_symbols_custom=mupen_rglgen_resolve_symbols_custom \
-      -Drglgen_resolve_symbols=mupen_rglgen_resolve_symbols \
-      -Dmemalign_alloc=mupen_memalign_alloc \
-      -Dmemalign_free=mupen_memalign_free \
-      -Dmemalign_alloc_aligned=mupen_memalign_alloc_aligned \
-      -Daudio_resampler_driver_find_handle=mupen_audio_resampler_driver_find_handle \
-      -Daudio_resampler_driver_find_ident=mupen_audio_resampler_driver_find_ident \
-      -Drarch_resampler_realloc=mupen_rarch_resampler_realloc \
-      -Dconvert_float_to_s16_C=mupen_convert_float_to_s16_C \
-      -Dconvert_float_to_s16_init_simd=mupen_convert_float_to_s16_init_simd \
-      -Dconvert_s16_to_float_C=mupen_convert_s16_to_float_C \
-      -Dconvert_s16_to_float_init_simd=mupen_convert_s16_to_float_init_simd \
-      -Dcpu_features_get_perf_counter=mupen_cpu_features_get_perf_counter \
-      -Dcpu_features_get_time_usec=mupen_cpu_features_get_time_usec \
-      -Dcpu_features_get_core_amount=mupen_cpu_features_get_core_amount \
-      -Dcpu_features_get=mupen_cpu_features_get \
-      -Dffs=mupen_ffs \
-      -Dstrlcpy_retro__=mupen_strlcpy_retro__ \
-      -Dstrlcat_retro__=mupen_strlcat_retro__
-
 
    WITH_DYNAREC =
-	CC = emcc
+   CC = emcc
    CXX = em++
    HAVE_NEON = 0
    PLATFORM_EXT := unix
-	STATIC_LINKING=1
+   STATIC_LINKING = 1
+   SOURCES_C += $(CORE_DIR)/src/r4300/empty_dynarec.c
    #HAVE_SHARED_CONTEXT := 1
 
 # PlayStation Vita
@@ -388,7 +365,7 @@ else ifneq (,$(findstring vita,$(platform)))
    CPUCFLAGS += -DNO_ASM
    CFLAGS += -DVITA -lm
    VITA = 1
-	HAVE_PARALLEL=0
+   HAVE_PARALLEL=0
    SOURCES_C += $(CORE_DIR)/src/r4300/empty_dynarec.c
 
    PLATFORM_EXT := unix
@@ -743,7 +720,7 @@ endif
 COREFLAGS += -D__LIBRETRO__ -DM64P_PLUGIN_API -DM64P_CORE_PROTOTYPES -D_ENDUSER_RELEASE -DSINC_LOWER_QUALITY
 
 OBJOUT   = -o
-LINKOUT  = -o 
+LINKOUT  = -o
 
 ifneq (,$(findstring msvc,$(platform)))
 	OBJOUT = -Fo
@@ -803,7 +780,7 @@ else ifeq ($(HAVE_PARALLEL), 1)
      CXXFLAGS += -MMD
    else
      CFLAGS   += -MT
-     CXXFLAGS += -MT     
+     CXXFLAGS += -MT
    endif
 else ifeq (,$(findstring msvc,$(platform)))
     CFLAGS   += -MMD
@@ -825,7 +802,7 @@ endif
 
 ifeq ($(WANT_CXX11),1)
 ifeq (,$(findstring msvc,$(platform)))
-CXXFLAGS += -std=c++0x 
+CXXFLAGS += -std=c++0x
 endif
 endif
 
@@ -874,7 +851,7 @@ endif
 
 %.o: %.S
 ifneq (,$(findstring msvc,$(platform)))
-	$(CC_AS) $(ASFLAGS) -o$@ $< 
+	$(CC_AS) $(ASFLAGS) -o$@ $<
 else
 	$(CC_AS) $(ASFLAGS) -c $< $(OBJOUT)$@
 endif

--- a/gles2n64/src/OpenGL.c
+++ b/gles2n64/src/OpenGL.c
@@ -151,7 +151,7 @@ static void _updateViewport(void)
    float Xf = gSP.viewport.vscale[0] < 0 ? (gSP.viewport.x + gSP.viewport.vscale[0] * 2.0f) : gSP.viewport.x;
    const GLint X = (GLint)(Xf * scaleX);
    const GLint Y = gSP.viewport.vscale[1] < 0 ? (GLint)((gSP.viewport.y + gSP.viewport.vscale[1] * 2.0f) * scaleY) : (GLint)((VI_height - (gSP.viewport.y + gSP.viewport.height)) * scaleY);
-   
+
    glViewport(X,
          Y + OGL_GetHeightOffset(),
          MAX((GLint)(gSP.viewport.width * scaleX), 0),
@@ -180,7 +180,7 @@ static void _updateScissor(struct FrameBuffer *_pBuffer)
       scaleX       = OGL_GetScaleX();
       scaleY       = OGL_GetScaleY();
       heightOffset = OGL_GetHeightOffset();
-      screenHeight = VI.height; 
+      screenHeight = VI.height;
    }
    else
    {
@@ -782,8 +782,8 @@ bool texturedRectDepthBufferCopy(const struct TexturedRectParams *_params)
 	// Works only with depth buffer emulation enabled.
 	// Load of arbitrary data to that area causes weird camera rotation in CBFD.
 	const struct gDPTile *pTile = (const struct gDPTile*)gSP.textureTile[0];
-	if (pTile->loadType == LOADTYPE_BLOCK && gDP.textureImage.size == 2 
-         && gDP.textureImage.address >= gDP.depthImageAddress 
+	if (pTile->loadType == LOADTYPE_BLOCK && gDP.textureImage.size == 2
+         && gDP.textureImage.address >= gDP.depthImageAddress
          &&  gDP.textureImage.address < (gDP.depthImageAddress + gDP.colorImage.width*gDP.colorImage.width * 6 / 4))
    {
       uint32_t x;
@@ -1084,7 +1084,7 @@ void OGL_ClearDepthBuffer(bool _fullsize)
 #endif
 
    glDisable( GL_SCISSOR_TEST );
-   glDepthMask( GL_TRUE ); 
+   glDepthMask( GL_TRUE );
    glClear( GL_DEPTH_BUFFER_BIT );
 
    _updateDepthUpdate();
@@ -1123,7 +1123,7 @@ int OGL_CheckError(void)
 
 void OGL_SwapBuffers(void)
 {
-   void retro_return(bool a);
+   int retro_return(int a);
    // if emulator defined a render callback function, call it before
    // buffer swap
    if (renderCallback)

--- a/glide2gl/src/Glide64/glidemain.c
+++ b/glide2gl/src/Glide64/glidemain.c
@@ -86,7 +86,7 @@ VOODOO voodoo = {0, 0};
 
 uint32_t   offset_textures = 0;
 
-// SOME FUNCTION DEFINITIONS 
+// SOME FUNCTION DEFINITIONS
 
 void glide_set_filtering(unsigned value);
 
@@ -622,7 +622,7 @@ output:   none
 *******************************************************************/
 uint32_t update_screen_count = 0;
 
-void retro_return(bool a);
+int retro_return(int a);
 
 void glide64UpdateScreen (void)
 {

--- a/libretro-common/audio/conversion/float_to_s16.c
+++ b/libretro-common/audio/conversion/float_to_s16.c
@@ -42,7 +42,7 @@ void convert_float_s16_asm(int16_t *out, const float *in, size_t samples);
  * @in                : input buffer
  * @samples           : size of samples to be converted
  *
- * Converts floating point 
+ * Converts floating point
  * to signed integer 16-bit.
  *
  * C implementation callback function.
@@ -72,7 +72,7 @@ void convert_float_to_s16(int16_t *out,
 #elif defined(__ALTIVEC__)
    int samples_in = samples;
 
-   /* Unaligned loads/store is a bit expensive, 
+   /* Unaligned loads/store is a bit expensive,
     * so we optimize for the good path (very likely). */
    if (((uintptr_t)out & 15) + ((uintptr_t)in & 15) == 0)
    {
@@ -106,7 +106,7 @@ void convert_float_to_s16(int16_t *out,
 #elif defined(_MIPS_ARCH_ALLEGREX)
 
 #ifdef DEBUG
-   /* Make sure the buffers are 16 byte aligned, this should be 
+   /* Make sure the buffers are 16 byte aligned, this should be
     * the default behaviour of malloc in the PSPSDK.
     * Assume alignment. */
    retro_assert(((uintptr_t)in  & 0xf) == 0);
@@ -135,7 +135,7 @@ void convert_float_to_s16(int16_t *out,
 
 #endif
 
-   for (i = 0; i < samples; i++)
+   for (; i < samples; i++)
    {
       int32_t val = (int32_t)(in[i] * 0x8000);
       out[i]      = (val > 0x7FFF) ? 0x7FFF :

--- a/libretro-common/audio/conversion/s16_to_float.c
+++ b/libretro-common/audio/conversion/s16_to_float.c
@@ -73,7 +73,7 @@ void convert_s16_to_float(float *out,
 #elif defined(__ALTIVEC__)
    size_t samples_in = samples;
 
-   /* Unaligned loads/store is a bit expensive, so we 
+   /* Unaligned loads/store is a bit expensive, so we
     * optimize for the good path (very likely). */
    if (((uintptr_t)out & 15) + ((uintptr_t)in & 15) == 0)
    {
@@ -115,7 +115,7 @@ void convert_s16_to_float(float *out,
 
 #elif defined(_MIPS_ARCH_ALLEGREX)
 #ifdef DEBUG
-   /* Make sure the buffer is 16 byte aligned, this should be the 
+   /* Make sure the buffer is 16 byte aligned, this should be the
     * default behaviour of malloc in the PSPSDK.
     * Only the output buffer can be assumed to be 16-byte aligned. */
    retro_assert(((uintptr_t)out & 0xf) == 0);
@@ -169,7 +169,7 @@ void convert_s16_to_float(float *out,
    gain    = gain / 0x8000;
 
    for (; i < samples; i++)
-      out[i] = (float)in[i] * gain; 
+      out[i] = (float)in[i] * gain;
 }
 
 /**

--- a/libretro-common/audio/resampler/audio_resampler.c
+++ b/libretro-common/audio/resampler/audio_resampler.c
@@ -1,4 +1,4 @@
-/* Copyright  (C) 2010-2016 The RetroArch team
+/* Copyright  (C) 2010-2017 The RetroArch team
  *
  * ---------------------------------------------------------------------------------------
  * The following license statement only applies to this file (audio_resampler.c).
@@ -127,11 +127,13 @@ static const retro_resampler_t *find_resampler_driver(const char *ident)
  **/
 static bool resampler_append_plugs(void **re,
       const retro_resampler_t **backend,
+      enum resampler_quality quality,
       double bw_ratio)
 {
-   resampler_simd_mask_t mask = cpu_features_get();
+   resampler_simd_mask_t mask = (resampler_simd_mask_t)cpu_features_get();
 
-   *re = (*backend)->init(&resampler_config, bw_ratio, mask);
+   if (*backend)
+      *re = (*backend)->init(&resampler_config, bw_ratio, quality, mask);
 
    if (!*re)
       return false;
@@ -145,13 +147,13 @@ static bool resampler_append_plugs(void **re,
  * @ident                      : Identifier name for resampler we want.
  * @bw_ratio                   : Bandwidth ratio.
  *
- * Reallocates resampler. Will free previous handle before 
+ * Reallocates resampler. Will free previous handle before
  * allocating a new one. If ident is NULL, first resampler will be used.
  *
  * Returns: true (1) if successful, otherwise false (0).
  **/
 bool retro_resampler_realloc(void **re, const retro_resampler_t **backend,
-      const char *ident, double bw_ratio)
+      const char *ident, enum resampler_quality quality, double bw_ratio)
 {
    if (*re && *backend)
       (*backend)->free(*re);
@@ -159,7 +161,7 @@ bool retro_resampler_realloc(void **re, const retro_resampler_t **backend,
    *re      = NULL;
    *backend = find_resampler_driver(ident);
 
-   if (!resampler_append_plugs(re, backend, bw_ratio))
+   if (!resampler_append_plugs(re, backend, quality, bw_ratio))
    {
       if (!*re)
          *backend = NULL;

--- a/libretro-common/audio/resampler/drivers/nearest_resampler.c
+++ b/libretro-common/audio/resampler/drivers/nearest_resampler.c
@@ -23,14 +23,14 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <math.h>
- 
+
 #include <audio/audio_resampler.h>
 
 typedef struct rarch_nearest_resampler
 {
    float fraction;
 } rarch_nearest_resampler_t;
- 
+
 static void resampler_nearest_process(
       void *re_, struct resampler_data *data)
 {
@@ -39,7 +39,7 @@ static void resampler_nearest_process(
    audio_frame_float_t  *inp_max = (audio_frame_float_t*)inp + data->input_frames;
    audio_frame_float_t  *outp    = (audio_frame_float_t*)data->data_out;
    float                   ratio = 1.0 / data->ratio;
- 
+
    while(inp != inp_max)
    {
       while(re->fraction > 1)
@@ -48,21 +48,23 @@ static void resampler_nearest_process(
          re->fraction -= ratio;
       }
       re->fraction++;
-      inp++;      
+      inp++;
    }
-   
+
    data->output_frames = (outp - (audio_frame_float_t*)data->data_out);
 }
- 
+
 static void resampler_nearest_free(void *re_)
 {
    rarch_nearest_resampler_t *re = (rarch_nearest_resampler_t*)re_;
    if (re)
       free(re);
 }
- 
+
 static void *resampler_nearest_init(const struct resampler_config *config,
-      double bandwidth_mod, resampler_simd_mask_t mask)
+      double bandwidth_mod, 
+      enum resampler_quality quality,
+      resampler_simd_mask_t mask)
 {
    rarch_nearest_resampler_t *re = (rarch_nearest_resampler_t*)
       calloc(1, sizeof(rarch_nearest_resampler_t));
@@ -72,12 +74,12 @@ static void *resampler_nearest_init(const struct resampler_config *config,
 
    if (!re)
       return NULL;
-   
+
    re->fraction = 0;
-   
+
    return re;
 }
- 
+
 retro_resampler_t nearest_resampler = {
    resampler_nearest_init,
    resampler_nearest_process,

--- a/libretro-common/audio/resampler/drivers/null_resampler.c
+++ b/libretro-common/audio/resampler/drivers/null_resampler.c
@@ -23,29 +23,31 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <math.h>
- 
+
 #include <audio/audio_resampler.h>
 
 typedef struct rarch_null_resampler
 {
    void *empty;
 } rarch_null_resampler_t;
- 
+
 static void resampler_null_process(
       void *re_, struct resampler_data *data)
 {
 }
- 
+
 static void resampler_null_free(void *re_)
 {
 }
- 
+
 static void *resampler_null_init(const struct resampler_config *config,
-      double bandwidth_mod, resampler_simd_mask_t mask)
+      double bandwidth_mod, 
+      enum resampler_quality quality,
+      resampler_simd_mask_t mask)
 {
    return (void*)0;
 }
- 
+
 retro_resampler_t null_resampler = {
    resampler_null_init,
    resampler_null_process,

--- a/libretro-common/audio/resampler/drivers/sinc_resampler.c
+++ b/libretro-common/audio/resampler/drivers/sinc_resampler.c
@@ -38,7 +38,7 @@
 #include <xmmintrin.h>
 #endif
 
-#if defined(__AVX__) && ENABLE_AVX
+#if defined(__AVX__)
 #include <immintrin.h>
 #endif
 
@@ -51,58 +51,13 @@
  */
 
 /* TODO, make all this more configurable. */
-#if defined(SINC_LOWEST_QUALITY)
-#define SINC_WINDOW_LANCZOS
-#define CUTOFF 0.98
-#define PHASE_BITS 12
-#define SINC_COEFF_LERP 0
-#define SUBPHASE_BITS 10
-#define SIDELOBES 2
-#define ENABLE_AVX 0
-#elif defined(SINC_LOWER_QUALITY)
-#define SINC_WINDOW_LANCZOS
-#define CUTOFF 0.98
-#define PHASE_BITS 12
-#define SUBPHASE_BITS 10
-#define SINC_COEFF_LERP 0
-#define SIDELOBES 4
-#define ENABLE_AVX 0
-#elif defined(SINC_HIGHER_QUALITY)
-#define SINC_WINDOW_KAISER
-#define SINC_WINDOW_KAISER_BETA 10.5
-#define CUTOFF 0.90
-#define PHASE_BITS 10
-#define SUBPHASE_BITS 14
-#define SINC_COEFF_LERP 1
-#define SIDELOBES 32
-#define ENABLE_AVX 1
-#elif defined(SINC_HIGHEST_QUALITY)
-#define SINC_WINDOW_KAISER
-#define SINC_WINDOW_KAISER_BETA 14.5
-#define CUTOFF 0.962
-#define PHASE_BITS 10
-#define SUBPHASE_BITS 14
-#define SINC_COEFF_LERP 1
-#define SIDELOBES 128
-#define ENABLE_AVX 1
-#else
-#define SINC_WINDOW_KAISER
-#define SINC_WINDOW_KAISER_BETA 5.5
-#define CUTOFF 0.825
-#define PHASE_BITS 8
-#define SUBPHASE_BITS 16
-#define SINC_COEFF_LERP 1
-#define SIDELOBES 8
-#define ENABLE_AVX 0
-#endif
 
-#if defined(SINC_WINDOW_LANCZOS)
-#define window_function(idx)  (lanzcos_window_function(idx))
-#elif defined(SINC_WINDOW_KAISER)
-#define window_function(idx)  (kaiser_window_function(idx, SINC_WINDOW_KAISER_BETA))
-#else
-#error "No SINC window function defined."
-#endif
+enum sinc_window
+{
+   SINC_WINDOW_NONE   = 0,
+   SINC_WINDOW_KAISER,
+   SINC_WINDOW_LANCZOS
+};
 
 /* For the little amount of taps we're using,
  * SSE1 is faster than AVX for some reason.
@@ -110,42 +65,39 @@
  * of sinc taps, the AVX code is clearly faster than SSE1.
  */
 
-#define PHASES (1 << (PHASE_BITS + SUBPHASE_BITS))
-
-#define TAPS (SIDELOBES * 2)
-#define SUBPHASE_MASK ((1 << SUBPHASE_BITS) - 1)
-#define SUBPHASE_MOD (1.0f / (1 << SUBPHASE_BITS))
-
 typedef struct rarch_sinc_resampler
 {
-   float *phase_table;
-   float *buffer_l;
-   float *buffer_r;
-
+   unsigned enable_avx;
+   unsigned phase_bits;
+   unsigned subphase_bits;
+   unsigned subphase_mask;
    unsigned taps;
-
    unsigned ptr;
    uint32_t time;
+   float subphase_mod;
+   float kaiser_beta;
+   enum sinc_window window_type;
 
-   /* A buffer for phase_table, buffer_l and buffer_r 
+   /* A buffer for phase_table, buffer_l and buffer_r
     * are created in a single calloc().
     * Ensure that we get as good cache locality as we can hope for. */
    float *main_buffer;
-
-   bool neon_enabled;
+   float *phase_table;
+   float *buffer_l;
+   float *buffer_r;
 } rarch_sinc_resampler_t;
 
-#if defined(__ARM_NEON__) && !defined(SINC_COEFF_LERP)
+#if defined(__ARM_NEON__)
 /* Assumes that taps >= 8, and that taps is a multiple of 8. */
-void process_sinc_neon_asm(float *out, const float *left, 
+void process_sinc_neon_asm(float *out, const float *left,
       const float *right, const float *coeff, unsigned taps);
-#endif
 
-static void resampler_sinc_process(void *re_, struct resampler_data *data)
+static void resampler_sinc_process_neon(void *re_, struct resampler_data *data)
 {
    rarch_sinc_resampler_t *resamp = (rarch_sinc_resampler_t*)re_;
+   unsigned phases                = 1 << (resamp->phase_bits + resamp->subphase_bits);
 
-   uint32_t ratio                 = PHASES / data->ratio;
+   uint32_t ratio                 = phases / data->ratio;
    const float *input             = data->data_in;
    float *output                  = data->data_out;
    size_t frames                  = data->input_frames;
@@ -153,62 +105,121 @@ static void resampler_sinc_process(void *re_, struct resampler_data *data)
 
    while (frames)
    {
-      while (frames && resamp->time >= PHASES)
+      while (frames && resamp->time >= phases)
       {
          /* Push in reverse to make filter more obvious. */
          if (!resamp->ptr)
             resamp->ptr = resamp->taps;
          resamp->ptr--;
 
-         resamp->buffer_l[resamp->ptr + resamp->taps] = 
+         resamp->buffer_l[resamp->ptr + resamp->taps] =
          resamp->buffer_l[resamp->ptr]                = *input++;
 
-         resamp->buffer_r[resamp->ptr + resamp->taps] = 
+         resamp->buffer_r[resamp->ptr + resamp->taps] =
          resamp->buffer_r[resamp->ptr]                = *input++;
 
-         resamp->time                                -= PHASES;
+         resamp->time                                -= phases;
          frames--;
       }
 
-      while (resamp->time < PHASES)
+      while (resamp->time < phases)
       {
          unsigned i;
          const float *buffer_l    = resamp->buffer_l + resamp->ptr;
          const float *buffer_r    = resamp->buffer_r + resamp->ptr;
          unsigned taps            = resamp->taps;
-         unsigned phase           = resamp->time >> SUBPHASE_BITS;
-#if SINC_COEFF_LERP
-         const float *phase_table = resamp->phase_table + phase * taps * 2;
-         const float *delta_table = phase_table + taps;
-#else
+         unsigned phase           = resamp->time >> resamp->subphase_bits;
          const float *phase_table = resamp->phase_table + phase * taps;
+
+         process_sinc_neon_asm(output, buffer_l, buffer_r, phase_table, taps);
+
+         output += 2;
+         out_frames++;
+         resamp->time += ratio;
+      }
+   }
+
+   data->output_frames = out_frames;
+}
 #endif
 
-#if defined(__AVX__) && ENABLE_AVX
-         __m256 sum_l             = _mm256_setzero_ps();
-         __m256 sum_r             = _mm256_setzero_ps();
-#if SINC_COEFF_LERP
-         __m256 delta             = _mm256_set1_ps((float)
-               (resamp->time & SUBPHASE_MASK) * SUBPHASE_MOD);
-#endif
+#if defined(__AVX__)
+static void resampler_sinc_process_avx(void *re_, struct resampler_data *data)
+{
+   rarch_sinc_resampler_t *resamp = (rarch_sinc_resampler_t*)re_;
+   unsigned phases                = 1 << (resamp->phase_bits + resamp->subphase_bits);
+
+   uint32_t ratio                 = phases / data->ratio;
+   const float *input             = data->data_in;
+   float *output                  = data->data_out;
+   size_t frames                  = data->input_frames;
+   size_t out_frames              = 0;
+
+   while (frames)
+   {
+      while (frames && resamp->time >= phases)
+      {
+         /* Push in reverse to make filter more obvious. */
+         if (!resamp->ptr)
+            resamp->ptr = resamp->taps;
+         resamp->ptr--;
+
+         resamp->buffer_l[resamp->ptr + resamp->taps] =
+         resamp->buffer_l[resamp->ptr]                = *input++;
+
+         resamp->buffer_r[resamp->ptr + resamp->taps] =
+         resamp->buffer_r[resamp->ptr]                = *input++;
+
+         resamp->time                                -= phases;
+         frames--;
+      }
+
+      while (resamp->time < phases)
+      {
+         unsigned i;
+         __m256 delta, sum_l, sum_r;
+         float *delta_table       = NULL;
+         float *phase_table       = NULL;
+         const float *buffer_l    = resamp->buffer_l + resamp->ptr;
+         const float *buffer_r    = resamp->buffer_r + resamp->ptr;
+         unsigned taps            = resamp->taps;
+         unsigned phase           = resamp->time >> resamp->subphase_bits;
+
+         phase_table              = resamp->phase_table + phase * taps;
+
+         if (resamp->window_type == SINC_WINDOW_KAISER)
+         {
+            phase_table              = resamp->phase_table + phase * taps * 2;
+            delta_table              = phase_table + taps;
+            delta                    = _mm256_set1_ps((float)
+                  (resamp->time & resamp->subphase_mask) * resamp->subphase_mod);
+         }
+
+         sum_l                    = _mm256_setzero_ps();
+         sum_r                    = _mm256_setzero_ps();
 
          for (i = 0; i < taps; i += 8)
          {
+            __m256 sinc;
             __m256 buf_l  = _mm256_loadu_ps(buffer_l + i);
             __m256 buf_r  = _mm256_loadu_ps(buffer_r + i);
 
-#if SINC_COEFF_LERP
-            __m256 deltas = _mm256_load_ps(delta_table + i);
-            __m256 sinc   = _mm256_add_ps(_mm256_load_ps(phase_table + i),
-                  _mm256_mul_ps(deltas, delta));
-#else
-            __m256 sinc   = _mm256_load_ps(phase_table + i);
-#endif
+            if (resamp->window_type == SINC_WINDOW_KAISER)
+            {
+               __m256 deltas = _mm256_load_ps(delta_table + i);
+               sinc          = _mm256_add_ps(_mm256_load_ps((const float*)phase_table + i),
+                     _mm256_mul_ps(deltas, delta));
+            }
+            else
+            {
+               sinc          = _mm256_load_ps((const float*)phase_table + i);
+            }
+
             sum_l         = _mm256_add_ps(sum_l, _mm256_mul_ps(buf_l, sinc));
             sum_r         = _mm256_add_ps(sum_r, _mm256_mul_ps(buf_r, sinc));
          }
 
-         /* hadd on AVX is weird, and acts on low-lanes 
+         /* hadd on AVX is weird, and acts on low-lanes
           * and high-lanes separately. */
          __m256 res_l = _mm256_hadd_ps(sum_l, sum_l);
          __m256 res_r = _mm256_hadd_ps(sum_r, sum_r);
@@ -221,27 +232,90 @@ static void resampler_sinc_process(void *re_, struct resampler_data *data)
           * There doesn't seem to be any _mm256_store_ss intrinsic. */
          _mm_store_ss(output + 0, _mm256_extractf128_ps(res_l, 0));
          _mm_store_ss(output + 1, _mm256_extractf128_ps(res_r, 0));
-#elif defined(__SSE__)
-         __m128 sum;
-         __m128 sum_l             = _mm_setzero_ps();
-         __m128 sum_r             = _mm_setzero_ps();
-#if SINC_COEFF_LERP
-         __m128 delta             = _mm_set1_ps((float)
-               (resamp->time & SUBPHASE_MASK) * SUBPHASE_MOD);
+
+         output += 2;
+         out_frames++;
+         resamp->time += ratio;
+      }
+   }
+
+   data->output_frames = out_frames;
+}
 #endif
+
+#if defined(__SSE__)
+static void resampler_sinc_process_sse(void *re_, struct resampler_data *data)
+{
+   rarch_sinc_resampler_t *resamp = (rarch_sinc_resampler_t*)re_;
+   unsigned phases                = 1 << (resamp->phase_bits + resamp->subphase_bits);
+
+   uint32_t ratio                 = phases / data->ratio;
+   const float *input             = data->data_in;
+   float *output                  = data->data_out;
+   size_t frames                  = data->input_frames;
+   size_t out_frames              = 0;
+
+   while (frames)
+   {
+      while (frames && resamp->time >= phases)
+      {
+         /* Push in reverse to make filter more obvious. */
+         if (!resamp->ptr)
+            resamp->ptr = resamp->taps;
+         resamp->ptr--;
+
+         resamp->buffer_l[resamp->ptr + resamp->taps] =
+         resamp->buffer_l[resamp->ptr]                = *input++;
+
+         resamp->buffer_r[resamp->ptr + resamp->taps] =
+         resamp->buffer_r[resamp->ptr]                = *input++;
+
+         resamp->time                                -= phases;
+         frames--;
+      }
+
+      while (resamp->time < phases)
+      {
+         unsigned i;
+         __m128 sum, sum_l, sum_r, delta;
+         float *phase_table       = NULL;
+         float *delta_table       = NULL;
+         const float *buffer_l    = resamp->buffer_l + resamp->ptr;
+         const float *buffer_r    = resamp->buffer_r + resamp->ptr;
+         unsigned taps            = resamp->taps;
+         unsigned phase           = resamp->time >> resamp->subphase_bits;
+
+         if (resamp->window_type == SINC_WINDOW_KAISER)
+         {
+            phase_table              = resamp->phase_table + phase * taps * 2;
+            delta_table              = phase_table + taps;
+            delta                    = _mm_set1_ps((float)
+                  (resamp->time & resamp->subphase_mask) * resamp->subphase_mod);
+         }
+         else
+         {
+            phase_table              = resamp->phase_table + phase * taps;
+         }
+
+         sum_l                    = _mm_setzero_ps();
+         sum_r                    = _mm_setzero_ps();
 
          for (i = 0; i < taps; i += 4)
          {
+            __m128 deltas, _sinc;
             __m128 buf_l = _mm_loadu_ps(buffer_l + i);
             __m128 buf_r = _mm_loadu_ps(buffer_r + i);
 
-#if SINC_COEFF_LERP
-            __m128 deltas = _mm_load_ps(delta_table + i);
-            __m128 _sinc  = _mm_add_ps(_mm_load_ps(phase_table + i),
-                  _mm_mul_ps(deltas, delta));
-#else
-            __m128 _sinc = _mm_load_ps(phase_table + i);
-#endif
+            if (resamp->window_type == SINC_WINDOW_KAISER)
+            {
+               deltas = _mm_load_ps(delta_table + i);
+               _sinc  = _mm_add_ps(_mm_load_ps((const float*)phase_table + i),
+                     _mm_mul_ps(deltas, delta));
+            }
+            else
+            {
+               _sinc  = _mm_load_ps((const float*)phase_table + i);
+            }
             sum_l        = _mm_add_ps(sum_l, _mm_mul_ps(buf_l, _sinc));
             sum_r        = _mm_add_ps(sum_r, _mm_mul_ps(buf_r, _sinc));
          }
@@ -262,7 +336,7 @@ static void resampler_sinc_process(void *re_, struct resampler_data *data)
          sum = _mm_add_ps(_mm_shuffle_ps(sum, sum, _MM_SHUFFLE(3, 3, 1, 1)), sum);
 
          /* sum   = {R1, R1, L1, L1 } + { R1, R0, L1, L0 }
-          * sum   = { X,  R,  X,  L } 
+          * sum   = { X,  R,  X,  L }
           */
 
          /* Store L */
@@ -270,41 +344,6 @@ static void resampler_sinc_process(void *re_, struct resampler_data *data)
 
          /* movehl { X, R, X, L } == { X, R, X, R } */
          _mm_store_ss(output + 1, _mm_movehl_ps(sum, sum));
-#elif defined(__ARM_NEON__) && !defined(SINC_COEFF_LERP)
-         if (resamp->neon_enabled)
-         {
-            process_sinc_neon_asm(output, buffer_l, buffer_r, phase_table, taps);
-
-            output += 2;
-            out_frames++;
-            resamp->time += ratio;
-            continue;
-         }
-#else
-         {
-            /* Plain ol' C */
-            float sum_l              = 0.0f;
-            float sum_r              = 0.0f;
-#if SINC_COEFF_LERP
-            float delta              = (float)
-               (resamp->time & SUBPHASE_MASK) * SUBPHASE_MOD;
-#endif
-
-            for (i = 0; i < taps; i++)
-            {
-#if SINC_COEFF_LERP
-               float sinc_val = phase_table[i] + delta_table[i] * delta;
-#else
-               float sinc_val = phase_table[i];
-#endif
-               sum_l         += buffer_l[i] * sinc_val;
-               sum_r         += buffer_r[i] * sinc_val;
-            }
-
-            output[0] = sum_l;
-            output[1] = sum_r;
-         }
-#endif
 
          output += 2;
          out_frames++;
@@ -314,12 +353,101 @@ static void resampler_sinc_process(void *re_, struct resampler_data *data)
 
    data->output_frames = out_frames;
 }
+#endif
 
-static void sinc_init_table(rarch_sinc_resampler_t *resamp, double cutoff,
+static void resampler_sinc_process_c(void *re_, struct resampler_data *data)
+{
+   rarch_sinc_resampler_t *resamp = (rarch_sinc_resampler_t*)re_;
+   unsigned phases                = 1 << (resamp->phase_bits + resamp->subphase_bits);
+
+   uint32_t ratio                 = phases / data->ratio;
+   const float *input             = data->data_in;
+   float *output                  = data->data_out;
+   size_t frames                  = data->input_frames;
+   size_t out_frames              = 0;
+
+   while (frames)
+   {
+      while (frames && resamp->time >= phases)
+      {
+         /* Push in reverse to make filter more obvious. */
+         if (!resamp->ptr)
+            resamp->ptr = resamp->taps;
+         resamp->ptr--;
+
+         resamp->buffer_l[resamp->ptr + resamp->taps]    =
+            resamp->buffer_l[resamp->ptr]                = *input++;
+
+         resamp->buffer_r[resamp->ptr + resamp->taps]    =
+            resamp->buffer_r[resamp->ptr]                = *input++;
+
+         resamp->time                                   -= phases;
+         frames--;
+      }
+
+      while (resamp->time < phases)
+      {
+         unsigned i;
+         float delta              = 0.0f;
+         float sum_l              = 0.0f;
+         float sum_r              = 0.0f;
+         float *phase_table       = NULL;
+         float *delta_table       = NULL;
+         const float *buffer_l    = resamp->buffer_l + resamp->ptr;
+         const float *buffer_r    = resamp->buffer_r + resamp->ptr;
+         unsigned taps            = resamp->taps;
+         unsigned phase           = resamp->time >> resamp->subphase_bits;
+
+         if (resamp->window_type == SINC_WINDOW_KAISER)
+         {
+            phase_table              = resamp->phase_table + phase * taps * 2;
+            delta_table              = phase_table + taps;
+            delta                    = (float)
+               (resamp->time & resamp->subphase_mask) * resamp->subphase_mod;
+         }
+         else
+         {
+            phase_table              = resamp->phase_table + phase * taps;
+         }
+
+         for (i = 0; i < taps; i++)
+         {
+            float sinc_val = phase_table[i];
+
+            if (resamp->window_type == SINC_WINDOW_KAISER)
+               sinc_val    = sinc_val + delta_table[i] * delta;
+
+            sum_l         += buffer_l[i] * sinc_val;
+            sum_r         += buffer_r[i] * sinc_val;
+         }
+
+         output[0] = sum_l;
+         output[1] = sum_r;
+
+         output += 2;
+         out_frames++;
+         resamp->time += ratio;
+      }
+
+   }
+
+   data->output_frames = out_frames;
+}
+
+static void resampler_sinc_free(void *data)
+{
+   rarch_sinc_resampler_t *resamp = (rarch_sinc_resampler_t*)data;
+   if (resamp)
+      memalign_free(resamp->main_buffer);
+   free(resamp);
+}
+
+static void sinc_init_table_kaiser(rarch_sinc_resampler_t *resamp,
+      double cutoff,
       float *phase_table, int phases, int taps, bool calculate_delta)
 {
    int i, j;
-   double    window_mod = window_function(0.0); /* Need to normalize w(0) to 1.0. */
+   double    window_mod = kaiser_window_function(0.0, resamp->kaiser_beta); /* Need to normalize w(0) to 1.0. */
    int           stride = calculate_delta ? 2 : 1;
    double     sidelobes = taps / 2.0;
 
@@ -333,8 +461,8 @@ static void sinc_init_table(rarch_sinc_resampler_t *resamp, double cutoff,
          double window_phase = (double)n / (phases * taps); /* [0, 1). */
          window_phase        = 2.0 * window_phase - 1.0; /* [-1, 1) */
          sinc_phase          = sidelobes * window_phase;
-         val                 = cutoff * sinc(M_PI * sinc_phase * cutoff) * 
-            window_function(window_phase) / window_mod;
+         val                 = cutoff * sinc(M_PI * sinc_phase * cutoff) *
+            kaiser_window_function(window_phase, resamp->kaiser_beta) / window_mod;
          phase_table[i * stride * taps + j] = val;
       }
    }
@@ -348,7 +476,7 @@ static void sinc_init_table(rarch_sinc_resampler_t *resamp, double cutoff,
       {
          for (j = 0; j < taps; j++)
          {
-            float delta = phase_table[(p + 1) * stride * taps + j] - 
+            float delta = phase_table[(p + 1) * stride * taps + j] -
                phase_table[p * stride * taps + j];
             phase_table[(p * stride + 1) * taps + j] = delta;
          }
@@ -364,39 +492,140 @@ static void sinc_init_table(rarch_sinc_resampler_t *resamp, double cutoff,
          window_phase        = 2.0 * window_phase - 1.0; /* (-1, 1] */
          sinc_phase          = sidelobes * window_phase;
 
-         val                 = cutoff * sinc(M_PI * sinc_phase * cutoff) * 
-            window_function(window_phase) / window_mod;
+         val                 = cutoff * sinc(M_PI * sinc_phase * cutoff) *
+            kaiser_window_function(window_phase, resamp->kaiser_beta) / window_mod;
          delta = (val - phase_table[phase * stride * taps + j]);
          phase_table[(phase * stride + 1) * taps + j] = delta;
       }
    }
 }
 
-static void resampler_sinc_free(void *data)
+static void sinc_init_table_lanczos(rarch_sinc_resampler_t *resamp, double cutoff,
+      float *phase_table, int phases, int taps, bool calculate_delta)
 {
-   rarch_sinc_resampler_t *resamp = (rarch_sinc_resampler_t*)data;
-   if (resamp)
-      memalign_free(resamp->main_buffer);
-   free(resamp);
+   int i, j;
+   double    window_mod = lanzcos_window_function(0.0); /* Need to normalize w(0) to 1.0. */
+   int           stride = calculate_delta ? 2 : 1;
+   double     sidelobes = taps / 2.0;
+
+   for (i = 0; i < phases; i++)
+   {
+      for (j = 0; j < taps; j++)
+      {
+         double sinc_phase;
+         float val;
+         int               n = j * phases + i;
+         double window_phase = (double)n / (phases * taps); /* [0, 1). */
+         window_phase        = 2.0 * window_phase - 1.0; /* [-1, 1) */
+         sinc_phase          = sidelobes * window_phase;
+         val                 = cutoff * sinc(M_PI * sinc_phase * cutoff) *
+            lanzcos_window_function(window_phase) / window_mod;
+         phase_table[i * stride * taps + j] = val;
+      }
+   }
+
+   if (calculate_delta)
+   {
+      int phase;
+      int p;
+
+      for (p = 0; p < phases - 1; p++)
+      {
+         for (j = 0; j < taps; j++)
+         {
+            float delta = phase_table[(p + 1) * stride * taps + j] -
+               phase_table[p * stride * taps + j];
+            phase_table[(p * stride + 1) * taps + j] = delta;
+         }
+      }
+
+      phase = phases - 1;
+      for (j = 0; j < taps; j++)
+      {
+         float val, delta;
+         double sinc_phase;
+         int n               = j * phases + (phase + 1);
+         double window_phase = (double)n / (phases * taps); /* (0, 1]. */
+         window_phase        = 2.0 * window_phase - 1.0; /* (-1, 1] */
+         sinc_phase          = sidelobes * window_phase;
+
+         val                 = cutoff * sinc(M_PI * sinc_phase * cutoff) *
+            lanzcos_window_function(window_phase) / window_mod;
+         delta = (val - phase_table[phase * stride * taps + j]);
+         phase_table[(phase * stride + 1) * taps + j] = delta;
+      }
+   }
 }
 
 static void *resampler_sinc_new(const struct resampler_config *config,
-      double bandwidth_mod, resampler_simd_mask_t mask)
+      double bandwidth_mod, enum resampler_quality quality, 
+      resampler_simd_mask_t mask)
 {
-   double cutoff;
-   size_t phase_elems, elems;
-   rarch_sinc_resampler_t *re = (rarch_sinc_resampler_t*)
+   double cutoff                  = 0.0;
+   size_t phase_elems             = 0;
+   size_t elems                   = 0;
+   unsigned sidelobes             = 0;
+   rarch_sinc_resampler_t *re     = (rarch_sinc_resampler_t*)
       calloc(1, sizeof(*re));
 
    if (!re)
       return NULL;
 
-   (void)config;
+   re->window_type                = SINC_WINDOW_NONE;
 
-   re->taps = TAPS;
-   cutoff   = CUTOFF;
+   switch (quality)
+   {
+      case RESAMPLER_QUALITY_LOWEST:
+         cutoff            = 0.98;
+         sidelobes         = 2;
+         re->phase_bits    = 12;
+         re->subphase_bits = 10;
+         re->window_type   = SINC_WINDOW_LANCZOS;
+         re->enable_avx    = 0;
+         break;
+      case RESAMPLER_QUALITY_LOWER:
+         cutoff            = 0.98;
+         sidelobes         = 4;
+         re->phase_bits    = 12;
+         re->subphase_bits = 10;
+         re->window_type   = SINC_WINDOW_LANCZOS;
+         re->enable_avx    = 0;
+         break;
+      case RESAMPLER_QUALITY_HIGHER:
+         cutoff            = 0.90;
+         sidelobes         = 32;
+         re->phase_bits    = 10;
+         re->subphase_bits = 14;
+         re->window_type   = SINC_WINDOW_KAISER;
+         re->kaiser_beta   = 10.5;
+         re->enable_avx    = 1;
+         break;
+      case RESAMPLER_QUALITY_HIGHEST:
+         cutoff            = 0.962;
+         sidelobes         = 128;
+         re->phase_bits    = 10;
+         re->subphase_bits = 14;
+         re->window_type   = SINC_WINDOW_KAISER;
+         re->kaiser_beta   = 14.5;
+         re->enable_avx    = 1;
+         break;
+      case RESAMPLER_QUALITY_NORMAL:
+      case RESAMPLER_QUALITY_DONTCARE:
+         cutoff            = 0.825;
+         sidelobes         = 8;
+         re->phase_bits    = 8;
+         re->subphase_bits = 16;
+         re->window_type   = SINC_WINDOW_KAISER;
+         re->kaiser_beta   = 5.5;
+         re->enable_avx    = 0;
+         break;
+   }
 
-   /* Downsampling, must lower cutoff, and extend number of 
+   re->subphase_mask = (1 << re->subphase_bits) - 1;
+   re->subphase_mod  = 1.0f / (1 << re->subphase_bits);
+   re->taps          = sidelobes * 2;
+
+   /* Downsampling, must lower cutoff, and extend number of
     * taps accordingly to keep same stopband attenuation. */
    if (bandwidth_mod < 1.0)
    {
@@ -405,17 +634,23 @@ static void *resampler_sinc_new(const struct resampler_config *config,
    }
 
    /* Be SIMD-friendly. */
-#if (defined(__AVX__) && ENABLE_AVX) || (defined(__ARM_NEON__))
-   re->taps     = (re->taps + 7) & ~7;
+#if defined(__AVX__)
+   if (re->enable_avx)
+      re->taps  = (re->taps + 7) & ~7;
+   else
+#endif
+   {
+#if defined(__ARM_NEON__)
+      re->taps     = (re->taps + 7) & ~7;
 #else
-   re->taps     = (re->taps + 3) & ~3;
+      re->taps     = (re->taps + 3) & ~3;
 #endif
+   }
 
-   phase_elems  = (1 << PHASE_BITS) * re->taps;
-#if SINC_COEFF_LERP
-   phase_elems *= 2;
-#endif
-   elems        = phase_elems + 4 * re->taps;
+   phase_elems     = ((1 << re->phase_bits) * re->taps);
+   if (re->window_type == SINC_WINDOW_KAISER)
+      phase_elems  = phase_elems * 2;
+   elems           = phase_elems + 4 * re->taps;
 
    re->main_buffer = (float*)memalign_alloc(128, sizeof(float) * elems);
    if (!re->main_buffer)
@@ -425,13 +660,40 @@ static void *resampler_sinc_new(const struct resampler_config *config,
    re->buffer_l    = re->main_buffer + phase_elems;
    re->buffer_r    = re->buffer_l + 2 * re->taps;
 
-   sinc_init_table(re, cutoff, re->phase_table,
-         1 << PHASE_BITS, re->taps, SINC_COEFF_LERP);
+   switch (re->window_type)
+   {
+      case SINC_WINDOW_LANCZOS:
+         sinc_init_table_lanczos(re, cutoff, re->phase_table,
+               1 << re->phase_bits, re->taps, false);
+         break;
+      case SINC_WINDOW_KAISER:
+         sinc_init_table_kaiser(re, cutoff, re->phase_table,
+               1 << re->phase_bits, re->taps, true);
+         break;
+      case SINC_WINDOW_NONE:
+         goto error;
+   }
 
-#if defined(__ARM_NEON__) 
-   if (mask & RESAMPLER_SIMD_NEON)
-      re->neon_enabled = true;
+   sinc_resampler.process = resampler_sinc_process_c;
+
+   if (mask & RESAMPLER_SIMD_AVX && re->enable_avx)
+   {
+#if defined(__AVX__)
+      sinc_resampler.process = resampler_sinc_process_avx;
 #endif
+   }
+   else if (mask & RESAMPLER_SIMD_SSE)
+   {
+#if defined(__SSE__)
+      sinc_resampler.process = resampler_sinc_process_sse;
+#endif
+   }
+   else if (mask & RESAMPLER_SIMD_NEON && re->window_type != SINC_WINDOW_KAISER)
+   {
+#if defined(__ARM_NEON__)
+      sinc_resampler.process = resampler_sinc_process_neon;
+#endif
+   }
 
    return re;
 
@@ -442,7 +704,7 @@ error:
 
 retro_resampler_t sinc_resampler = {
    resampler_sinc_new,
-   resampler_sinc_process,
+   resampler_sinc_process_c,
    resampler_sinc_free,
    RESAMPLER_API_VERSION,
    "sinc",

--- a/libretro-common/glsm/glsm.c
+++ b/libretro-common/glsm/glsm.c
@@ -163,7 +163,7 @@ struct gl_cached_state
       GLenum mode;
    } frontface;
 
-   struct 
+   struct
    {
       bool used;
       GLenum mode;
@@ -189,7 +189,7 @@ struct gl_cached_state
    GLuint vao;
    GLuint framebuf;
    GLuint array_buffer;
-   GLuint program; 
+   GLuint program;
    GLenum active_texture;
    int cap_state[SGL_CAP_MAX];
    int cap_translate[SGL_CAP_MAX];
@@ -359,7 +359,7 @@ void rglFrontFace(GLenum mode)
    glsm_ctl(GLSM_CTL_IMM_VBO_DRAW, NULL);
    glFrontFace(mode);
    gl_state.frontface.used = true;
-   gl_state.frontface.mode = mode; 
+   gl_state.frontface.mode = mode;
 }
 
 /*
@@ -505,22 +505,22 @@ void rglBlendFunc(GLenum sfactor, GLenum dfactor)
  * Core in:
  * OpenGL    : 1.4
  */
-void rglBlendFuncSeparate(GLenum sfactor, GLenum dfactor)
+void rglBlendFuncSeparate(GLenum sfactorRGB, GLenum dfactorRGB, GLenum sfactorAlpha, GLenum dfactorAlpha)
 {
    glsm_ctl(GLSM_CTL_IMM_VBO_DRAW, NULL);
    gl_state.blendfunc_separate.used     = true;
-   gl_state.blendfunc_separate.srcRGB   = sfactor;
-   gl_state.blendfunc_separate.dstRGB   = dfactor;
-   gl_state.blendfunc_separate.srcAlpha = sfactor;
-   gl_state.blendfunc_separate.dstAlpha = dfactor;
-   glBlendFunc(sfactor, dfactor);
+   gl_state.blendfunc_separate.srcRGB   = sfactorRGB;
+   gl_state.blendfunc_separate.dstRGB   = dfactorRGB;
+   gl_state.blendfunc_separate.srcAlpha = sfactorAlpha;
+   gl_state.blendfunc_separate.dstAlpha = dfactorAlpha;
+   glBlendFuncSeparate(sfactorRGB, dfactorRGB, sfactorAlpha, dfactorAlpha);
 }
 
 /*
  * Category: Textures
  *
  * Core in:
- * OpenGL    : 1.3 
+ * OpenGL    : 1.3
  */
 void rglActiveTexture(GLenum texture)
 {
@@ -569,7 +569,7 @@ void rglEnable(GLenum cap)
  * Category: Shaders
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglUseProgram(GLuint program)
 {
@@ -653,7 +653,7 @@ void rglLinkProgram(GLuint program)
  * Category: FBO
  *
  * Core in:
- * OpenGL    : 3.0 
+ * OpenGL    : 3.0
  * OpenGLES  : 2.0
  */
 void rglFramebufferTexture2D(GLenum target, GLenum attachment,
@@ -702,7 +702,7 @@ void rglCompressedTexImage2D(GLenum target, GLint level,
       GLenum internalformat, GLsizei width, GLsizei height,
       GLint border, GLsizei imageSize, const GLvoid *data)
 {
-   glCompressedTexImage2D(target, level, internalformat, 
+   glCompressedTexImage2D(target, level, internalformat,
          width, height, border, imageSize, data);
 }
 
@@ -720,7 +720,7 @@ void rglDeleteTextures(GLsizei n, const GLuint *textures)
 /*
  *
  * Core in:
- * OpenGLES    : 2.0 
+ * OpenGLES    : 2.0
  */
 void rglRenderbufferStorage(GLenum target, GLenum internalFormat,
       GLsizei width, GLsizei height)
@@ -733,7 +733,7 @@ void rglRenderbufferStorage(GLenum target, GLenum internalFormat,
  * Core in:
  *
  * OpenGL      : 3.0
- * OpenGLES    : 2.0 
+ * OpenGLES    : 2.0
  */
 void rglBindRenderbuffer(GLenum target, GLuint renderbuffer)
 {
@@ -744,7 +744,7 @@ void rglBindRenderbuffer(GLenum target, GLuint renderbuffer)
  *
  * Core in:
  *
- * OpenGLES    : 2.0 
+ * OpenGLES    : 2.0
  */
 void rglDeleteRenderbuffers(GLsizei n, GLuint *renderbuffers)
 {
@@ -756,7 +756,7 @@ void rglDeleteRenderbuffers(GLsizei n, GLuint *renderbuffers)
  * Core in:
  *
  * OpenGL      : 3.0
- * OpenGLES    : 2.0 
+ * OpenGLES    : 2.0
  */
 void rglGenRenderbuffers(GLsizei n, GLuint *renderbuffers)
 {
@@ -768,7 +768,7 @@ void rglGenRenderbuffers(GLsizei n, GLuint *renderbuffers)
  * Core in:
  *
  * OpenGL      : 3.0
- * OpenGLES    : 2.0 
+ * OpenGLES    : 2.0
  */
 void rglGenerateMipmap(GLenum target)
 {
@@ -779,7 +779,7 @@ void rglGenerateMipmap(GLenum target)
  * Category: FBO
  *
  * Core in:
- * OpenGL    : 3.0 
+ * OpenGL    : 3.0
  */
 GLenum rglCheckFramebufferStatus(GLenum target)
 {
@@ -790,7 +790,7 @@ GLenum rglCheckFramebufferStatus(GLenum target)
  * Category: FBO
  *
  * Core in:
- * OpenGL    : 3.0 
+ * OpenGL    : 3.0
  * OpenGLES  : 2.0
  */
 void rglFramebufferRenderbuffer(GLenum target, GLenum attachment,
@@ -803,7 +803,7 @@ void rglFramebufferRenderbuffer(GLenum target, GLenum attachment,
  * Category: Shaders
  *
  * Core in:
- * OpenGL    : 3.0 
+ * OpenGL    : 3.0
  */
 void rglBindFragDataLocation(GLuint program, GLuint colorNumber,
                                    const char * name)
@@ -818,7 +818,7 @@ void rglBindFragDataLocation(GLuint program, GLuint colorNumber,
  * Category: Shaders
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglGetProgramiv(GLuint shader, GLenum pname, GLint *params)
 {
@@ -829,7 +829,7 @@ void rglGetProgramiv(GLuint shader, GLenum pname, GLint *params)
  * Category: Shaders
  *
  * Core in:
- * OpenGL    : 4.1 
+ * OpenGL    : 4.1
  * OpenGLES  : 3.0
  */
 void rglProgramParameteri( 	GLuint program,
@@ -846,7 +846,7 @@ void rglProgramParameteri( 	GLuint program,
 /*
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglGetActiveUniform(GLuint program, GLuint index, GLsizei bufsize,
       GLsizei *length, GLint *size, GLenum *type, GLchar *name)
@@ -859,7 +859,7 @@ void rglGetActiveUniform(GLuint program, GLuint index, GLsizei bufsize,
  *
  * Core in:
  *
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  * OpenGLES  : 3.0
  */
 void rglGetActiveUniformBlockiv(GLuint program,
@@ -973,7 +973,7 @@ void rglUniformBlockBinding( 	GLuint program,
 /*
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  * OpenGLES  : 3.0
  */
 void rglUniform1ui(GLint location, GLuint v)
@@ -986,7 +986,7 @@ void rglUniform1ui(GLint location, GLuint v)
 /*
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  * OpenGLES  : 3.0
  */
 void rglUniform2ui(GLint location, GLuint v0, GLuint v1)
@@ -999,7 +999,7 @@ void rglUniform2ui(GLint location, GLuint v0, GLuint v1)
 /*
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  * OpenGLES  : 3.0
  */
 void rglUniform3ui(GLint location, GLuint v0, GLuint v1, GLuint v2)
@@ -1012,7 +1012,7 @@ void rglUniform3ui(GLint location, GLuint v0, GLuint v1, GLuint v2)
 /*
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  * OpenGLES  : 3.0
  */
 void rglUniform4ui(GLint location, GLuint v0, GLuint v1, GLuint v2, GLuint v3)
@@ -1025,7 +1025,7 @@ void rglUniform4ui(GLint location, GLuint v0, GLuint v1, GLuint v2, GLuint v3)
 /*
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglUniformMatrix4fv(GLint location, GLsizei count, GLboolean transpose,
       const GLfloat *value)
@@ -1037,7 +1037,7 @@ void rglUniformMatrix4fv(GLint location, GLsizei count, GLboolean transpose,
  * Category: Shaders
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglDetachShader(GLuint program, GLuint shader)
 {
@@ -1048,7 +1048,7 @@ void rglDetachShader(GLuint program, GLuint shader)
  * Category: Shaders
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglGetShaderiv(GLuint shader, GLenum pname, GLint *params)
 {
@@ -1059,7 +1059,7 @@ void rglGetShaderiv(GLuint shader, GLenum pname, GLint *params)
  * Category: Shaders
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglAttachShader(GLuint program, GLuint shader)
 {
@@ -1069,7 +1069,7 @@ void rglAttachShader(GLuint program, GLuint shader)
 /*
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 GLint rglGetAttribLocation(GLuint program, const GLchar *name)
 {
@@ -1080,7 +1080,7 @@ GLint rglGetAttribLocation(GLuint program, const GLchar *name)
  * Category: Shaders
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglShaderSource(GLuint shader, GLsizei count,
       const GLchar **string, const GLint *length)
@@ -1092,7 +1092,7 @@ void rglShaderSource(GLuint shader, GLsizei count,
  * Category: Shaders
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglCompileShader(GLuint shader)
 {
@@ -1103,7 +1103,7 @@ void rglCompileShader(GLuint shader)
  * Category: Shaders
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 GLuint rglCreateProgram(void)
 {
@@ -1113,7 +1113,7 @@ GLuint rglCreateProgram(void)
 /*
  *
  * Core in:
- * OpenGL    : 1.1 
+ * OpenGL    : 1.1
  */
 void rglGenTextures(GLsizei n, GLuint *textures)
 {
@@ -1123,7 +1123,7 @@ void rglGenTextures(GLsizei n, GLuint *textures)
 /*
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglGetShaderInfoLog(GLuint shader, GLsizei maxLength,
       GLsizei *length, GLchar *infoLog)
@@ -1134,7 +1134,7 @@ void rglGetShaderInfoLog(GLuint shader, GLsizei maxLength,
 /*
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglGetProgramInfoLog(GLuint shader, GLsizei maxLength,
       GLsizei *length, GLchar *infoLog)
@@ -1145,7 +1145,7 @@ void rglGetProgramInfoLog(GLuint shader, GLsizei maxLength,
 /*
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 GLboolean rglIsProgram(GLuint program)
 {
@@ -1164,7 +1164,7 @@ void rglTexCoord2f(GLfloat s, GLfloat t)
  * Category: Generic vertex attributes
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  *
  */
 void rglDisableVertexAttribArray(GLuint index)
@@ -1177,7 +1177,7 @@ void rglDisableVertexAttribArray(GLuint index)
  * Category: Generic vertex attributes
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglEnableVertexAttribArray(GLuint index)
 {
@@ -1190,7 +1190,7 @@ void rglEnableVertexAttribArray(GLuint index)
  * Category: Shaders
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglVertexAttribIPointer(
       GLuint index,
@@ -1220,7 +1220,7 @@ void rglVertexAttribLPointer(
  * Category: Generic vertex attributes
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglVertexAttribPointer(GLuint name, GLint size,
       GLenum type, GLboolean normalized, GLsizei stride,
@@ -1240,7 +1240,7 @@ void rglVertexAttribPointer(GLuint name, GLint size,
  * Category: Generic vertex attributes
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglBindAttribLocation(GLuint program, GLuint index, const GLchar *name)
 {
@@ -1250,7 +1250,7 @@ void rglBindAttribLocation(GLuint program, GLuint index, const GLchar *name)
 /*
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglVertexAttrib4f(GLuint name, GLfloat x, GLfloat y,
       GLfloat z, GLfloat w)
@@ -1261,7 +1261,7 @@ void rglVertexAttrib4f(GLuint name, GLfloat x, GLfloat y,
 /*
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglVertexAttrib4fv(GLuint name, GLfloat* v)
 {
@@ -1272,7 +1272,7 @@ void rglVertexAttrib4fv(GLuint name, GLfloat* v)
  * Category: Shaders
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 GLuint rglCreateShader(GLenum shaderType)
 {
@@ -1283,7 +1283,7 @@ GLuint rglCreateShader(GLenum shaderType)
  * Category: Shaders
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglDeleteProgram(GLuint program)
 {
@@ -1294,7 +1294,7 @@ void rglDeleteProgram(GLuint program)
  * Category: Shaders
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglDeleteShader(GLuint shader)
 {
@@ -1305,7 +1305,7 @@ void rglDeleteShader(GLuint shader)
  * Category: Shaders
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 GLint rglGetUniformLocation(GLuint program, const GLchar *name)
 {
@@ -1316,7 +1316,7 @@ GLint rglGetUniformLocation(GLuint program, const GLchar *name)
  * Category: VBO and PBO
  *
  * Core in:
- * OpenGL    : 1.5 
+ * OpenGL    : 1.5
  */
 void rglDeleteBuffers(GLsizei n, const GLuint *buffers)
 {
@@ -1327,7 +1327,7 @@ void rglDeleteBuffers(GLsizei n, const GLuint *buffers)
  * Category: VBO and PBO
  *
  * Core in:
- * OpenGL    : 1.5 
+ * OpenGL    : 1.5
  */
 void rglGenBuffers(GLsizei n, GLuint *buffers)
 {
@@ -1338,7 +1338,7 @@ void rglGenBuffers(GLsizei n, GLuint *buffers)
  * Category: Shaders
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglUniform1f(GLint location, GLfloat v0)
 {
@@ -1349,7 +1349,7 @@ void rglUniform1f(GLint location, GLfloat v0)
  * Category: Shaders
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglUniform1fv(GLint location,  GLsizei count,  const GLfloat *value)
 {
@@ -1360,7 +1360,7 @@ void rglUniform1fv(GLint location,  GLsizei count,  const GLfloat *value)
  * Category: Shaders
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglUniform1iv(GLint location,  GLsizei count,  const GLint *value)
 {
@@ -1386,7 +1386,7 @@ void rglTexBuffer(GLenum target, GLenum internalFormat, GLuint buffer)
 /*
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  * OpenGLES  : 3.0
  */
 const GLubyte* rglGetStringi(GLenum name, GLuint index)
@@ -1411,7 +1411,7 @@ void rglClearBufferfi( 	GLenum buffer,
 /*
  *
  * Core in:
- * OpenGL    : 3.0 
+ * OpenGL    : 3.0
  * OpenGLES  : 3.0
  */
 void rglRenderbufferStorageMultisample( 	GLenum target,
@@ -1429,7 +1429,7 @@ void rglRenderbufferStorageMultisample( 	GLenum target,
  * Category: Shaders
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglUniform1i(GLint location, GLint v0)
 {
@@ -1440,7 +1440,7 @@ void rglUniform1i(GLint location, GLint v0)
  * Category: Shaders
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglUniform2f(GLint location, GLfloat v0, GLfloat v1)
 {
@@ -1451,7 +1451,7 @@ void rglUniform2f(GLint location, GLfloat v0, GLfloat v1)
  * Category: Shaders
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglUniform2i(GLint location, GLint v0, GLint v1)
 {
@@ -1462,7 +1462,7 @@ void rglUniform2i(GLint location, GLint v0, GLint v1)
  * Category: Shaders
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglUniform2fv(GLint location, GLsizei count, const GLfloat *value)
 {
@@ -1473,7 +1473,7 @@ void rglUniform2fv(GLint location, GLsizei count, const GLfloat *value)
  * Category: Shaders
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglUniform3f(GLint location, GLfloat v0, GLfloat v1, GLfloat v2)
 {
@@ -1484,7 +1484,7 @@ void rglUniform3f(GLint location, GLfloat v0, GLfloat v1, GLfloat v2)
  * Category: Shaders
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglUniform3fv(GLint location, GLsizei count, const GLfloat *value)
 {
@@ -1506,7 +1506,7 @@ void rglUniform4i(GLint location, GLint v0, GLint v1, GLint v2, GLint v3)
  * Category: Shaders
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglUniform4f(GLint location, GLfloat v0, GLfloat v1, GLfloat v2, GLfloat v3)
 {
@@ -1517,7 +1517,7 @@ void rglUniform4f(GLint location, GLfloat v0, GLfloat v1, GLfloat v2, GLfloat v3
  * Category: Shaders
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglUniform4fv(GLint location, GLsizei count, const GLfloat *value)
 {
@@ -1528,7 +1528,7 @@ void rglUniform4fv(GLint location, GLsizei count, const GLfloat *value)
 /*
  *
  * Core in:
- * OpenGL    : 1.0 
+ * OpenGL    : 1.0
  */
 void rglPolygonOffset(GLfloat factor, GLfloat units)
 {
@@ -1543,7 +1543,7 @@ void rglPolygonOffset(GLfloat factor, GLfloat units)
  * Category: FBO
  *
  * Core in:
- * OpenGL    : 3.0 
+ * OpenGL    : 3.0
  */
 void rglGenFramebuffers(GLsizei n, GLuint *ids)
 {
@@ -1554,7 +1554,7 @@ void rglGenFramebuffers(GLsizei n, GLuint *ids)
  * Category: FBO
  *
  * Core in:
- * OpenGL    : 3.0 
+ * OpenGL    : 3.0
  */
 void rglBindFramebuffer(GLenum target, GLuint framebuffer)
 {
@@ -1567,7 +1567,7 @@ void rglBindFramebuffer(GLenum target, GLuint framebuffer)
  * Category: FBO
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  * OpenGLES  : 3.0
  */
 void rglDrawBuffers(GLsizei n, const GLenum *bufs)
@@ -1581,7 +1581,7 @@ void rglDrawBuffers(GLsizei n, const GLenum *bufs)
  * Category: FBO
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  * OpenGLES  : 3.0
  */
 void *rglMapBufferRange( 	GLenum target,
@@ -1629,7 +1629,7 @@ void rglTexStorage2D(GLenum target, GLsizei levels, GLenum internalFormat,
 /*
  *
  * Core in:
- * OpenGL    : 4.2 
+ * OpenGL    : 4.2
  * OpenGLES  : 3.1
  */
 void rglMemoryBarrier( 	GLbitfield barriers)
@@ -1644,7 +1644,7 @@ void rglMemoryBarrier( 	GLbitfield barriers)
 /*
  *
  * Core in:
- * OpenGL    : 4.2 
+ * OpenGL    : 4.2
  * OpenGLES  : 3.1
  */
 void rglBindImageTexture( 	GLuint unit,
@@ -1714,7 +1714,7 @@ void rglTexImage2DMultisample( 	GLenum target,
 /*
  *
  * Core in:
- * OpenGL    : 1.5 
+ * OpenGL    : 1.5
  */
 void * rglMapBuffer(	GLenum target, GLenum access)
 {
@@ -1728,7 +1728,7 @@ void * rglMapBuffer(	GLenum target, GLenum access)
 /*
  *
  * Core in:
- * OpenGL    : 1.5 
+ * OpenGL    : 1.5
  */
 GLboolean rglUnmapBuffer( 	GLenum target)
 {
@@ -1753,7 +1753,7 @@ void rglBlendColor(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha)
  * Category: Blending
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  */
 void rglBlendEquationSeparate(GLenum modeRGB, GLenum modeAlpha)
 {
@@ -1763,7 +1763,7 @@ void rglBlendEquationSeparate(GLenum modeRGB, GLenum modeAlpha)
 /*
  *
  * Core in:
- * OpenGL    : 2.0 
+ * OpenGL    : 2.0
  * OpenGLES  : 3.2
  */
 void rglCopyImageSubData( 	GLuint srcName,
@@ -1805,7 +1805,7 @@ void rglCopyImageSubData( 	GLuint srcName,
  * Category: VAO
  *
  * Core in:
- * OpenGL    : 3.0 
+ * OpenGL    : 3.0
  * OpenGLES  : 3.0
  */
 void rglBindVertexArray(GLuint array)
@@ -1819,7 +1819,7 @@ void rglBindVertexArray(GLuint array)
  * Category: VAO
  *
  * Core in:
- * OpenGL    : 3.0 
+ * OpenGL    : 3.0
  * OpenGLES  : 3.0
  */
 void rglGenVertexArrays(GLsizei n, GLuint *arrays)
@@ -1833,7 +1833,7 @@ void rglGenVertexArrays(GLsizei n, GLuint *arrays)
  * Category: VAO
  *
  * Core in:
- * OpenGL    : 3.0 
+ * OpenGL    : 3.0
  * OpenGLES  : 3.0
  */
 void rglDeleteVertexArrays(GLsizei n, const GLuint *arrays)
@@ -1973,7 +1973,7 @@ static void glsm_state_setup(void)
 
    gl_state.framebuf                    = hw_render.get_current_framebuffer();
    gl_state.cullface.mode               = GL_BACK;
-   gl_state.frontface.mode              = GL_CCW; 
+   gl_state.frontface.mode              = GL_CCW;
 
    gl_state.blendfunc_separate.used     = false;
    gl_state.blendfunc_separate.srcRGB   = GL_ONE;
@@ -1982,7 +1982,7 @@ static void glsm_state_setup(void)
    gl_state.blendfunc_separate.dstAlpha = GL_ZERO;
 
    gl_state.depthfunc.used              = false;
-   
+
    gl_state.colormask.used              = false;
    gl_state.colormask.red               = GL_TRUE;
    gl_state.colormask.green             = GL_TRUE;

--- a/libretro-common/include/audio/audio_resampler.h
+++ b/libretro-common/include/audio/audio_resampler.h
@@ -1,4 +1,4 @@
-/* Copyright  (C) 2010-2016 The RetroArch team
+/* Copyright  (C) 2010-2017 The RetroArch team
  *
  * ---------------------------------------------------------------------------------------
  * The following license statement only applies to this file (audio_resampler.h).
@@ -47,8 +47,18 @@ RETRO_BEGIN_DECLS
 #define RESAMPLER_SIMD_VFPU     (1 << 13)
 #define RESAMPLER_SIMD_PS       (1 << 14)
 
+enum resampler_quality
+{
+   RESAMPLER_QUALITY_DONTCARE = 0,
+   RESAMPLER_QUALITY_LOWEST,
+   RESAMPLER_QUALITY_LOWER,
+   RESAMPLER_QUALITY_NORMAL,
+   RESAMPLER_QUALITY_HIGHER,
+   RESAMPLER_QUALITY_HIGHEST
+};
+
 /* A bit-mask of all supported SIMD instruction sets.
- * Allows an implementation to pick different 
+ * Allows an implementation to pick different
  * resampler_implementation structs.
  */
 typedef unsigned resampler_simd_mask_t;
@@ -66,7 +76,7 @@ struct resampler_data
    double ratio;
 };
 
-/* Returns true if config key was found. Otherwise, 
+/* Returns true if config key was found. Otherwise,
  * returns false, and sets value to default value.
  */
 typedef int (*resampler_config_get_float_t)(void *userdata,
@@ -76,7 +86,7 @@ typedef int (*resampler_config_get_int_t)(void *userdata,
       const char *key, int *value, int default_value);
 
 /* Allocates an array with values. free() with resampler_config_free_t. */
-typedef int (*resampler_config_get_float_array_t)(void *userdata, 
+typedef int (*resampler_config_get_float_array_t)(void *userdata,
       const char *key, float **values, unsigned *out_num_values,
       const float *default_values, unsigned num_default_values);
 
@@ -87,7 +97,7 @@ typedef int (*resampler_config_get_int_array_t)(void *userdata,
 typedef int (*resampler_config_get_string_t)(void *userdata,
       const char *key, char **output, const char *default_output);
 
-/* Calls free() in host runtime. Sometimes needed on Windows. 
+/* Calls free() in host runtime. Sometimes needed on Windows.
  * free() on NULL is fine. */
 typedef void (*resampler_config_free_t)(void *ptr);
 
@@ -100,15 +110,16 @@ struct resampler_config
    resampler_config_get_int_array_t get_int_array;
 
    resampler_config_get_string_t get_string;
-   /* Avoid problems where resampler plug and host are 
+   /* Avoid problems where resampler plug and host are
     * linked against different C runtimes. */
-   resampler_config_free_t free; 
+   resampler_config_free_t free;
 };
 
-/* Bandwidth factor. Will be < 1.0 for downsampling, > 1.0 for upsampling. 
+/* Bandwidth factor. Will be < 1.0 for downsampling, > 1.0 for upsampling.
  * Corresponds to expected resampling ratio. */
 typedef void *(*resampler_init_t)(const struct resampler_config *config,
-      double bandwidth_mod, resampler_simd_mask_t mask);
+      double bandwidth_mod, enum resampler_quality quality,
+      resampler_simd_mask_t mask);
 
 /* Frees the handle. */
 typedef void (*resampler_free_t)(void *data);
@@ -130,7 +141,7 @@ typedef struct retro_resampler
 
    /* Computer-friendly short version of ident.
     * Lower case, no spaces and special characters, etc. */
-   const char *short_ident; 
+   const char *short_ident;
 } retro_resampler_t;
 
 typedef struct audio_frame_float
@@ -171,13 +182,13 @@ const char *audio_resampler_driver_find_ident(int index);
  * @ident                      : Identifier name for resampler we want.
  * @bw_ratio                   : Bandwidth ratio.
  *
- * Reallocates resampler. Will free previous handle before 
+ * Reallocates resampler. Will free previous handle before
  * allocating a new one. If ident is NULL, first resampler will be used.
  *
  * Returns: true (1) if successful, otherwise false (0).
  **/
 bool retro_resampler_realloc(void **re, const retro_resampler_t **backend,
-      const char *ident, double bw_ratio);
+      const char *ident, enum resampler_quality quality, double bw_ratio);
 
 RETRO_END_DECLS
 

--- a/libretro-common/include/audio/conversion/float_to_s16.h
+++ b/libretro-common/include/audio/conversion/float_to_s16.h
@@ -36,7 +36,7 @@ RETRO_BEGIN_DECLS
  * @in                : input buffer
  * @samples           : size of samples to be converted
  *
- * Converts floating point 
+ * Converts floating point
  * to signed integer 16-bit.
  **/
 void convert_float_to_s16(int16_t *out,

--- a/mupen64plus-core/src/api/vidext_libretro.c
+++ b/mupen64plus-core/src/api/vidext_libretro.c
@@ -8,7 +8,7 @@
  *   the Free Software Foundation; either version 2 of the License, or     *
  *   (at your option) any later version.                                   *
  *                                                                         *
- *   This program is distributed in the hope that it will be useful,       * 
+ *   This program is distributed in the hope that it will be useful,       *
  *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
  *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
  *   GNU General Public License for more details.                          *
@@ -18,7 +18,7 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-                       
+
 /* This file contains the Core video extension functions which will be exported
  * outside of the core library.
  */
@@ -28,7 +28,7 @@
 
 #include <boolean.h>
 
-void retro_return(bool a);
+int retro_return(int a);
 
 #define M64P_CORE_PROTOTYPES 1
 #include "m64p_types.h"
@@ -121,7 +121,7 @@ EXPORT m64p_error CALL VidExt_Quit(void)
 EXPORT m64p_error CALL VidExt_SetVideoMode(int Width, int Height, int BitsPerPixel,
       m64p_video_mode ScreenMode, m64p_video_flags Flags)
 {
-   /* TODO/FIXME - implement. */ 
+   /* TODO/FIXME - implement. */
    return M64ERR_SUCCESS;
 }
 

--- a/mupen64plus-core/src/plugin/audio_libretro/audio_backend_libretro.c
+++ b/mupen64plus-core/src/plugin/audio_libretro/audio_backend_libretro.c
@@ -78,7 +78,7 @@ void deinit_audio_libretro(void)
 
 void init_audio_libretro(unsigned max_audio_frames)
 {
-   retro_resampler_realloc(&resampler_audio_data, &resampler, "sinc", 1.0);
+   retro_resampler_realloc(&resampler_audio_data, &resampler, "sinc", RESAMPLER_QUALITY_DONTCARE, 1.0);
 
    MAX_AUDIO_FRAMES = max_audio_frames;
 

--- a/mupen64plus-core/src/rsp/rsp_core.c
+++ b/mupen64plus-core/src/rsp/rsp_core.c
@@ -266,7 +266,7 @@ int write_rsp_regs2(void* opaque, uint32_t address, uint32_t value, uint32_t mas
 }
 
 /* forward declaration */
-void hleDoRspCycles(unsigned int value);
+unsigned int hleDoRspCycles(unsigned int value);
 extern uint32_t send_allist_to_hle_rsp;
 
 void do_SP_Task(struct rsp_core* sp)
@@ -279,7 +279,7 @@ void do_SP_Task(struct rsp_core* sp)
 	{
 	   /* Display list */
 	   /* don't do the task now
-	    * the task will be done when 
+	    * the task will be done when
 	    * DP is unfreezed (see update_dpc_status) */
 	   if (sp->dp->dpc_regs[DPC_STATUS_REG] & DPC_STATUS_FREEZE) /* DP frozen (DK64, BC) */
 	      return;

--- a/mupen64plus-video-angrylion/n64video.c
+++ b/mupen64plus-video-angrylion/n64video.c
@@ -1,5 +1,6 @@
 #include <stdarg.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include <boolean.h>
 #include <retro_miscellaneous.h>
@@ -56,9 +57,9 @@ typedef struct
 typedef struct {
     int stalederivs;
     int dolod;
-    int partialreject_1cycle; 
+    int partialreject_1cycle;
     int partialreject_2cycle;
-    int special_bsel0; 
+    int special_bsel0;
     int special_bsel1;
     int rgb_alpha_dither;
     int realblendershiftersneeded;
@@ -292,10 +293,10 @@ static TLS int32_t spans_d_stwz_dy[4];
 typedef struct
 {
     int tilenum;
-    uint16_t xl, yl, xh, yh;        
-    int16_t s, t;                    
-    int16_t dsdx, dtdy;            
-    uint32_t flip;    
+    uint16_t xl, yl, xh, yh;
+    int16_t s, t;
+    int16_t dsdx, dtdy;
+    uint32_t flip;
 } TEX_RECTANGLE;
 
 
@@ -330,7 +331,7 @@ TLS COLOR pre_memory_color;
 
 TLS int oldscyl = 0;
 
-TLS uint8_t __TMEM[0x1000]; 
+TLS uint8_t __TMEM[0x1000];
 
 #define tlut ((uint16_t*)(&__TMEM[0x800]))
 
@@ -395,8 +396,8 @@ uint16_t deltaz_comparator_lut[0x10000];
 static STRICTINLINE void tcmask(int32_t* S, int32_t* T, int32_t num)
 {
     int32_t wrap;
-    
-    
+
+
 
     if (tile[num].mask_s)
     {
@@ -417,7 +418,7 @@ static STRICTINLINE void tcmask(int32_t* S, int32_t* T, int32_t num)
             wrap &= 1;
             *T ^= (-wrap);
         }
-        
+
         *T &= tile[num].mask_t_maskbits;
     }
 }
@@ -425,8 +426,8 @@ static STRICTINLINE void tcmask(int32_t* S, int32_t* T, int32_t num)
 static STRICTINLINE void tcmask_coupled(int32_t* S, int32_t* S1, int32_t* T, int32_t* T1, int32_t num)
 {
     int32_t wrap;
-    int32_t maskbits; 
-    int32_t wrapthreshold; 
+    int32_t maskbits;
+    int32_t wrapthreshold;
 
 
     if (tile[num].mask_s)
@@ -468,8 +469,8 @@ static STRICTINLINE void tcmask_coupled(int32_t* S, int32_t* S1, int32_t* T, int
 static STRICTINLINE void tcmask_copy(int32_t* S, int32_t* S1, int32_t* S2, int32_t* S3, int32_t* T, int32_t num)
 {
     int32_t wrap;
-    int32_t maskbits_s; 
-    int32_t swrapthreshold; 
+    int32_t maskbits_s;
+    int32_t swrapthreshold;
 
     if (tile[num].mask_s)
     {
@@ -501,7 +502,7 @@ static STRICTINLINE void tcmask_copy(int32_t* S, int32_t* S1, int32_t* S2, int32
     {
         if (tile[num].mt)
         {
-            wrap = *T >> tile[num].f.masktclamped; 
+            wrap = *T >> tile[num].f.masktclamped;
             wrap &= 1;
             *T ^= (-wrap);
         }
@@ -525,14 +526,14 @@ static INLINE void tcshift_cycle(int32_t* S, int32_t* T, int32_t* maxs, int32_t*
         coord <<= (16 - shifter);
         coord = SIGN16(coord);
     }
-    *S = coord; 
+    *S = coord;
 
-    
 
-    
+
+
     *maxs = ((coord >> 3) >= tile[num].sh);
-    
-    
+
+
 
     coord = *T;
     shifter = tile[num].shift_t;
@@ -547,9 +548,9 @@ static INLINE void tcshift_cycle(int32_t* S, int32_t* T, int32_t* maxs, int32_t*
         coord <<= (16 - shifter);
         coord = SIGN16(coord);
     }
-    *T = coord; 
+    *T = coord;
     *maxt = ((coord >> 3) >= tile[num].th);
-}    
+}
 
 
 static INLINE void tcshift_copy(int32_t* S, int32_t* T, uint32_t num)
@@ -567,7 +568,7 @@ static INLINE void tcshift_copy(int32_t* S, int32_t* T, uint32_t num)
         coord <<= (16 - shifter);
         coord = SIGN16(coord);
     }
-    *S = coord; 
+    *S = coord;
 
     coord = *T;
     shifter = tile[num].shift_t;
@@ -582,8 +583,8 @@ static INLINE void tcshift_copy(int32_t* S, int32_t* T, uint32_t num)
         coord <<= (16 - shifter);
         coord = SIGN16(coord);
     }
-    *T = coord; 
-    
+    *T = coord;
+
 }
 
 static STRICTINLINE void tcclamp_cycle(int32_t* S, int32_t* T, int32_t* SFRAC, int32_t* TFRAC, int32_t maxs, int32_t maxt, int32_t num)
@@ -723,7 +724,7 @@ static INLINE void SET_BLENDER_INPUT(int cycle, int which, int16_t **input_r, in
     {
         switch (b & 0x3)
         {
-           case 0:       
+           case 0:
               *input_a = &COLOR_ALPHA(pixel_color);
               break;
            case 1:
@@ -741,7 +742,7 @@ static INLINE void SET_BLENDER_INPUT(int cycle, int which, int16_t **input_r, in
     {
         switch (b & 0x3)
         {
-            case 0: 
+            case 0:
                *input_a = &COLOR_ALPHA(inv_pixel_color);
                break;
             case 1:
@@ -940,12 +941,12 @@ static uint32_t vi_integer_sqrt(uint32_t a)
 {
     uint32_t op = a, res = 0, one = 1 << 30;
 
-    while (one > op) 
+    while (one > op)
         one >>= 2;
 
-    while (one != 0) 
+    while (one != 0)
     {
-        if (op >= res + one) 
+        if (op >= res + one)
         {
             op -= res + one;
             res += one << 1;
@@ -961,7 +962,7 @@ static void precalculate_everything(void)
     int ps[9];
     uint32_t exponent;
     uint32_t mantissa;
-    int temppoint, tempslope; 
+    int temppoint, tempslope;
     int normout;
     int wnorm;
     int shift, tlu_rcp;
@@ -1015,7 +1016,7 @@ static void precalculate_everything(void)
     }
 
     for (i = 0; i < 32; i++)
-        replicated_rgba[i] = (i << 3) | ((i >> 2) & 7); 
+        replicated_rgba[i] = (i << 3) | ((i >> 2) & 7);
 
     for(i = 0; i < 0x200; i++)
     {
@@ -1041,7 +1042,7 @@ static void precalculate_everything(void)
 
     for (i = 0; i < 0x8000; i++)
     {
-        for (k = 1; k <= 14 && !((i << k) & 0x8000); k++) 
+        for (k = 1; k <= 14 && !((i << k) & 0x8000); k++)
             ;
         shift = k - 1;
         normout = (i << shift) & 0x3fff;
@@ -1052,9 +1053,9 @@ static void precalculate_everything(void)
         tempslope = norm_slope_table[normout];
 
         tempslope = (tempslope | ~0x3ff) + 1;
-        
+
         tlu_rcp = (((tempslope * wnorm) >> 10) + temppoint) & 0x7fff;
-        
+
         tcdiv_table[i] = shift | (tlu_rcp << 4);
     }
 
@@ -1343,7 +1344,7 @@ static INLINE void SET_MUL_RGB_INPUT(int16_t **input_r, int16_t **input_g, int16
        case 10:
           *input_r = &COLOR_ALPHA(prim_color);
           *input_g = &COLOR_ALPHA(prim_color);
-          *input_b = &COLOR_ALPHA(prim_color); 
+          *input_b = &COLOR_ALPHA(prim_color);
           break;
        case 11:
           *input_r = &COLOR_ALPHA(shade_color);
@@ -1547,7 +1548,7 @@ static void combiner_1cycle(int adseed, uint32_t* curpixel_cvg)
        COLOR_GREEN(chromabypass) = *combiner_rgbsub_a_g[1];
        COLOR_BLUE(chromabypass)  = *combiner_rgbsub_a_b[1];
     }
-    
+
     temp_combined_color[0] = color_combiner_equation(*combiner_rgbsub_a_r[1],*combiner_rgbsub_b_r[1],*combiner_rgbmul_r[1],*combiner_rgbadd_r[1]);
     temp_combined_color[1] = color_combiner_equation(*combiner_rgbsub_a_g[1],*combiner_rgbsub_b_g[1],*combiner_rgbmul_g[1],*combiner_rgbadd_g[1]);
     temp_combined_color[2] = color_combiner_equation(*combiner_rgbsub_a_b[1],*combiner_rgbsub_b_b[1],*combiner_rgbmul_b[1],*combiner_rgbadd_b[1]);
@@ -1587,7 +1588,7 @@ static void combiner_1cycle(int adseed, uint32_t* curpixel_cvg)
         keyalpha = (bluekey < keyalpha) ? bluekey : keyalpha;
         keyalpha = CLIP(keyalpha, 0, 0xff);
 
-        
+
         COLOR_RED(pixel_color)   = special_9bit_clamptable[COLOR_RED(chromabypass)];
         COLOR_GREEN(pixel_color) = special_9bit_clamptable[COLOR_GREEN(chromabypass)];
         COLOR_BLUE(pixel_color)  = special_9bit_clamptable[COLOR_BLUE(chromabypass)];
@@ -1596,8 +1597,8 @@ static void combiner_1cycle(int adseed, uint32_t* curpixel_cvg)
         COLOR_GREEN(combined_color) = temp_combined_color[1] >> 8;
         COLOR_BLUE(combined_color)  = temp_combined_color[2] >> 8;
     }
-    
-    
+
+
     if (other_modes.cvg_times_alpha)
     {
         temp = (COLOR_ALPHA(pixel_color) * (*curpixel_cvg) + 4) >> 3;
@@ -1605,7 +1606,7 @@ static void combiner_1cycle(int adseed, uint32_t* curpixel_cvg)
     }
 
     if (!other_modes.alpha_cvg_select)
-    {    
+    {
         if (!other_modes.key_en)
         {
             COLOR_ALPHA(pixel_color) += adseed;
@@ -1624,7 +1625,7 @@ static void combiner_1cycle(int adseed, uint32_t* curpixel_cvg)
         if (COLOR_ALPHA(pixel_color) > 0xff)
             COLOR_ALPHA(pixel_color) = 0xff;
     }
-    
+
     COLOR_ALPHA(shade_color) += adseed;
     if (COLOR_ALPHA(shade_color) & 0x100)
         COLOR_ALPHA(shade_color) = 0xff;
@@ -1719,7 +1720,7 @@ static void combiner_2cycle(int adseed, uint32_t* curpixel_cvg, int32_t* acalpha
 
     if (!other_modes.key_en)
     {
-        
+
         COLOR_RED(combined_color)   = temp_combined_color[0]   >> 8;
         COLOR_GREEN(combined_color) = temp_combined_color[1] >> 8;
         COLOR_BLUE(combined_color)  = temp_combined_color[2] >> 8;
@@ -1752,17 +1753,17 @@ static void combiner_2cycle(int adseed, uint32_t* curpixel_cvg, int32_t* acalpha
         COLOR_RED(pixel_color)   = special_9bit_clamptable[COLOR_RED(chromabypass)];
         COLOR_GREEN(pixel_color) = special_9bit_clamptable[COLOR_GREEN(chromabypass)];
         COLOR_BLUE(pixel_color)  = special_9bit_clamptable[COLOR_BLUE(chromabypass)];
-        
+
         COLOR_RED(combined_color)   = temp_combined_color[0] >> 8;
         COLOR_GREEN(combined_color) = temp_combined_color[1] >> 8;
         COLOR_BLUE(combined_color)  = temp_combined_color[2] >> 8;
     }
-    
+
     COLOR_ALPHA(pixel_color) = special_9bit_clamptable[COLOR_ALPHA(combined_color)];
     if (COLOR_ALPHA(pixel_color) == 0xff)
         COLOR_ALPHA(pixel_color) = 0x100;
 
-    
+
     if (other_modes.cvg_times_alpha)
     {
         temp = (COLOR_ALPHA(pixel_color) * (*curpixel_cvg) + 4) >> 3;
@@ -1790,7 +1791,7 @@ static void combiner_2cycle(int adseed, uint32_t* curpixel_cvg, int32_t* acalpha
         if (COLOR_ALPHA(pixel_color) > 0xff)
             COLOR_ALPHA(pixel_color) = 0xff;
     }
-    
+
 
     COLOR_ALPHA(shade_color) += adseed;
     if (COLOR_ALPHA(shade_color) & 0x100)
@@ -1860,8 +1861,8 @@ static void blender_equation_cycle0(int* r, int* g, int* b)
 
     if (other_modes.force_blend)
     {
-       *r = (blr >> 5) & 0xff;    
-       *g = (blg >> 5) & 0xff; 
+       *r = (blr >> 5) & 0xff;
+       *g = (blg >> 5) & 0xff;
        *b = (blb >> 5) & 0xff;
     }
     else
@@ -1915,8 +1916,8 @@ static void blender_equation_cycle1(int* r, int* g, int* b)
 
     if (other_modes.force_blend)
     {
-       *r = (blr >> 5) & 0xff;    
-       *g = (blg >> 5) & 0xff; 
+       *r = (blr >> 5) & 0xff;
+       *g = (blg >> 5) & 0xff;
        *b = (blb >> 5) & 0xff;
     }
     else
@@ -2038,7 +2039,7 @@ static void fetch_texel(COLOR *color, int s, int t, uint32_t tilenum)
    {
       case TEXEL_RGBA4:
          {
-            uint8_t byteval, c; 
+            uint8_t byteval, c;
             taddr = ((tbase << 4) + s) >> 1;
             taddr ^= ((t & 1) ? BYTE_XOR_DWORD_SWAP : BYTE_ADDR_XOR);
 
@@ -2066,7 +2067,7 @@ static void fetch_texel(COLOR *color, int s, int t, uint32_t tilenum)
          }
          break;
       case TEXEL_RGBA16:
-         {         
+         {
             uint16_t c;
 
             taddr = (tbase << 2) + s;
@@ -2164,7 +2165,7 @@ static void fetch_texel(COLOR *color, int s, int t, uint32_t tilenum)
          }
          break;
       case TEXEL_CI16:
-         {         
+         {
             uint16_t c;
 
             taddr = (tbase << 2) + s;
@@ -2226,7 +2227,7 @@ static void fetch_texel(COLOR *color, int s, int t, uint32_t tilenum)
             uint16_t c;
 
             taddr = (tbase << 2) + s;
-            taddr ^= ((t & 1) ? WORD_XOR_DWORD_SWAP : WORD_ADDR_XOR);                         
+            taddr ^= ((t & 1) ? WORD_XOR_DWORD_SWAP : WORD_ADDR_XOR);
             c = tc16[taddr & 0x7ff];
             COLOR_RED_PTR(color) = COLOR_GREEN_PTR(color) = COLOR_BLUE_PTR(color) = (c >> 8);
             COLOR_ALPHA_PTR(color) = c & 0xff;
@@ -2274,11 +2275,11 @@ static void fetch_texel(COLOR *color, int s, int t, uint32_t tilenum)
          }
          break;
       case TEXEL_I16:
-         {        
+         {
             uint16_t c;
 
             taddr = (tbase << 2) + s;
-            taddr ^= ((t & 1) ? WORD_XOR_DWORD_SWAP : WORD_ADDR_XOR);    
+            taddr ^= ((t & 1) ? WORD_XOR_DWORD_SWAP : WORD_ADDR_XOR);
             c = tc16[taddr & 0x7ff];
             COLOR_RED_PTR(color) = c >> 8;
             COLOR_GREEN_PTR(color) = c & 0xff;
@@ -2291,7 +2292,7 @@ static void fetch_texel(COLOR *color, int s, int t, uint32_t tilenum)
             uint16_t c;
 
             taddr = (tbase << 2) + s;
-            taddr ^= ((t & 1) ? WORD_XOR_DWORD_SWAP : WORD_ADDR_XOR);   
+            taddr ^= ((t & 1) ? WORD_XOR_DWORD_SWAP : WORD_ADDR_XOR);
             c = tc16[taddr & 0x7ff];
             COLOR_RED_PTR(color) = c >> 8;
             COLOR_GREEN_PTR(color) = c & 0xff;
@@ -2626,7 +2627,7 @@ static void fetch_texel_quadro(COLOR *color0, COLOR *color1, COLOR *color2, COLO
             c0 = tc16[taddr0 >> 1];
             c1 = tc16[taddr1 >> 1];
             c2 = tc16[taddr2 >> 1];
-            c3 = tc16[taddr3 >> 1];                    
+            c3 = tc16[taddr3 >> 1];
 
             y0 = __TMEM[taddr0 + 0x800];
             u0 = c0 >> 8;
@@ -3374,7 +3375,7 @@ static void get_tmem_idx(int s, int t, uint32_t tilenum, uint32_t* idx0, uint32_
         tidx_d ^= 2;
     }
 
-    
+
     *idx0 = sort_tmem_idx(tidx_a, tidx_b, tidx_c, tidx_d, 0);
     *idx1 = sort_tmem_idx(tidx_a, tidx_b, tidx_c, tidx_d, 1);
     *idx2 = sort_tmem_idx(tidx_a, tidx_b, tidx_c, tidx_d, 2);
@@ -3486,7 +3487,7 @@ static void read_tmem_copy(int s, int s1, int s2, int s3,
    }
 
    hibits[0]  = (tidx_a & 0x1000) ? 1 : 0;
-   hibits[1]  = (tidx_blow & 0x1000) ? 1 : 0; 
+   hibits[1]  = (tidx_blow & 0x1000) ? 1 : 0;
    hibits[2]  = (tidx_bhi & 0x1000) ? 1 : 0;
    hibits[3]  = (tidx_c & 0x1000) ? 1 : 0;
    hibits[4]  = (tidx_dlow & 0x1000) ? 1 : 0;
@@ -3598,7 +3599,7 @@ static uint32_t replicate_for_copy(uint32_t inshort, uint32_t nybbleoffset,
    return (inshort >> 8) & 0xff;
 }
 
-static void tc_pipeline_copy(int32_t* sss0, int32_t* sss1, int32_t* sss2, int32_t* sss3, int32_t* sst, int tilenum)                                            
+static void tc_pipeline_copy(int32_t* sss0, int32_t* sss1, int32_t* sss2, int32_t* sss3, int32_t* sst, int tilenum)
 {
     int ss0 = *sss0, ss1 = 0, ss2 = 0, ss3 = 0, st = *sst;
 
@@ -3612,7 +3613,7 @@ static void tc_pipeline_copy(int32_t* sss0, int32_t* sss1, int32_t* sss2, int32_
     ss2 = ss0 + 2;
     ss3 = ss0 + 3;
 
-    tcmask_copy(&ss0, &ss1, &ss2, &ss3, &st, tilenum);    
+    tcmask_copy(&ss0, &ss1, &ss2, &ss3, &st, tilenum);
 
     *sss0 = ss0;
     *sss1 = ss1;
@@ -3697,7 +3698,7 @@ void angrylion_set_dithering(unsigned dither_type)
    angrylion_dithering = dither_type;
 }
 
-static void texture_pipeline_cycle(COLOR* TEX, COLOR* prev, int32_t SSS, int32_t SST, uint32_t tilenum, uint32_t cycle)                                            
+static void texture_pipeline_cycle(COLOR* TEX, COLOR* prev, int32_t SSS, int32_t SST, uint32_t tilenum, uint32_t cycle)
 {
     int32_t maxs, maxt, invt0r, invt0g, invt0b, invt0a;
     int32_t sfrac, tfrac, invsf, invtf;
@@ -3714,23 +3715,23 @@ static void texture_pipeline_cycle(COLOR* TEX, COLOR* prev, int32_t SSS, int32_t
     sss1 = TRELATIVE(sss1, tile[tilenum].sl);
     sst1 = TRELATIVE(sst1, tile[tilenum].tl);
 
-    if (other_modes.sample_type 
+    if (other_modes.sample_type
           && angrylion_filtering != 2)
-    {    
+    {
         sfrac = sss1 & 0x1f;
         tfrac = sst1 & 0x1f;
 
         tcclamp_cycle(&sss1, &sst1, &sfrac, &tfrac, maxs, maxt, tilenum);
-    
+
         if (tile[tilenum].format != FORMAT_YUV)
             sss2 = sss1 + 1;
         else
             sss2 = sss1 + 2;
 
         sst2 = sst1 + 1;
-        
+
         tcmask_coupled(&sss1, &sss2, &sst1, &sst2, tilenum);
-        
+
         if (bilerp)
         {
             if (!other_modes.en_tlut)
@@ -3746,16 +3747,16 @@ static void texture_pipeline_cycle(COLOR* TEX, COLOR* prev, int32_t SSS, int32_t
                     {
                         invsf = 0x20 - sfrac;
                         invtf = 0x20 - tfrac;
-                        COLOR_RED_PTR(TEX) = COLOR_RED(t3) + ((((invsf * (COLOR_RED(t2) - COLOR_RED(t3))) + (invtf * (COLOR_RED(t1) - COLOR_RED(t3)))) + 0x10) >> 5);    
-                        COLOR_GREEN_PTR(TEX) = COLOR_GREEN(t3) + ((((invsf * (COLOR_GREEN(t2) - COLOR_GREEN(t3))) + (invtf * (COLOR_GREEN(t1) - COLOR_GREEN(t3)))) + 0x10) >> 5);                                                                        
-                        COLOR_BLUE_PTR(TEX) = COLOR_BLUE(t3) + ((((invsf * (COLOR_BLUE(t2) - COLOR_BLUE(t3))) + (invtf * (COLOR_BLUE(t1) - COLOR_BLUE(t3)))) + 0x10) >> 5);                                                                
+                        COLOR_RED_PTR(TEX) = COLOR_RED(t3) + ((((invsf * (COLOR_RED(t2) - COLOR_RED(t3))) + (invtf * (COLOR_RED(t1) - COLOR_RED(t3)))) + 0x10) >> 5);
+                        COLOR_GREEN_PTR(TEX) = COLOR_GREEN(t3) + ((((invsf * (COLOR_GREEN(t2) - COLOR_GREEN(t3))) + (invtf * (COLOR_GREEN(t1) - COLOR_GREEN(t3)))) + 0x10) >> 5);
+                        COLOR_BLUE_PTR(TEX) = COLOR_BLUE(t3) + ((((invsf * (COLOR_BLUE(t2) - COLOR_BLUE(t3))) + (invtf * (COLOR_BLUE(t1) - COLOR_BLUE(t3)))) + 0x10) >> 5);
                         COLOR_ALPHA_PTR(TEX) = COLOR_ALPHA(t3) + ((((invsf * (COLOR_ALPHA(t2) - COLOR_ALPHA(t3))) + (invtf * (COLOR_ALPHA(t1) - COLOR_ALPHA(t3)))) + 0x10) >> 5);
                     }
                     else
                     {
-                       COLOR_RED_PTR(TEX) = COLOR_RED(t0) + ((((sfrac * (COLOR_RED(t1) - COLOR_RED(t0))) + (tfrac * (COLOR_RED(t2) - COLOR_RED(t0)))) + 0x10) >> 5);                                            
-                       COLOR_GREEN_PTR(TEX) = COLOR_GREEN(t0) + ((((sfrac * (COLOR_GREEN(t1) - COLOR_GREEN(t0))) + (tfrac * (COLOR_GREEN(t2) - COLOR_GREEN(t0)))) + 0x10) >> 5);                                            
-                       COLOR_BLUE_PTR(TEX) = COLOR_BLUE(t0) + ((((sfrac * (COLOR_BLUE(t1) - COLOR_BLUE(t0))) + (tfrac * (COLOR_BLUE(t2) - COLOR_BLUE(t0)))) + 0x10) >> 5);                                    
+                       COLOR_RED_PTR(TEX) = COLOR_RED(t0) + ((((sfrac * (COLOR_RED(t1) - COLOR_RED(t0))) + (tfrac * (COLOR_RED(t2) - COLOR_RED(t0)))) + 0x10) >> 5);
+                       COLOR_GREEN_PTR(TEX) = COLOR_GREEN(t0) + ((((sfrac * (COLOR_GREEN(t1) - COLOR_GREEN(t0))) + (tfrac * (COLOR_GREEN(t2) - COLOR_GREEN(t0)))) + 0x10) >> 5);
+                       COLOR_BLUE_PTR(TEX) = COLOR_BLUE(t0) + ((((sfrac * (COLOR_BLUE(t1) - COLOR_BLUE(t0))) + (tfrac * (COLOR_BLUE(t2) - COLOR_BLUE(t0)))) + 0x10) >> 5);
                        COLOR_ALPHA_PTR(TEX) = COLOR_ALPHA(t0) + ((((sfrac * (COLOR_ALPHA(t1) - COLOR_ALPHA(t0))) + (tfrac * (COLOR_ALPHA(t2) - COLOR_ALPHA(t0)))) + 0x10) >> 5);
                     }
                 }
@@ -3763,18 +3764,18 @@ static void texture_pipeline_cycle(COLOR* TEX, COLOR* prev, int32_t SSS, int32_t
                 {
                     if (UPPER)
                     {
-                       COLOR_RED_PTR(TEX) = COLOR_BLUE_PTR(prev) + ((((COLOR_RED_PTR(prev) * (COLOR_RED(t2) - COLOR_RED(t3))) + (COLOR_GREEN_PTR(prev) * (COLOR_RED(t1) - COLOR_RED(t3)))) + 0x80) >> 8);    
-                       COLOR_GREEN_PTR(TEX) = COLOR_BLUE_PTR(prev) + ((((COLOR_RED_PTR(prev) * (COLOR_GREEN(t2) - COLOR_GREEN(t3))) + (COLOR_GREEN_PTR(prev) * (COLOR_GREEN(t1) - COLOR_GREEN(t3)))) + 0x80) >> 8);                                                                        
-                       COLOR_BLUE_PTR(TEX) = COLOR_BLUE_PTR(prev) + ((((COLOR_RED_PTR(prev) * (COLOR_BLUE(t2) - COLOR_BLUE(t3))) + (COLOR_GREEN_PTR(prev) * (COLOR_BLUE(t1) - COLOR_BLUE(t3)))) + 0x80) >> 8);                                                                
+                       COLOR_RED_PTR(TEX) = COLOR_BLUE_PTR(prev) + ((((COLOR_RED_PTR(prev) * (COLOR_RED(t2) - COLOR_RED(t3))) + (COLOR_GREEN_PTR(prev) * (COLOR_RED(t1) - COLOR_RED(t3)))) + 0x80) >> 8);
+                       COLOR_GREEN_PTR(TEX) = COLOR_BLUE_PTR(prev) + ((((COLOR_RED_PTR(prev) * (COLOR_GREEN(t2) - COLOR_GREEN(t3))) + (COLOR_GREEN_PTR(prev) * (COLOR_GREEN(t1) - COLOR_GREEN(t3)))) + 0x80) >> 8);
+                       COLOR_BLUE_PTR(TEX) = COLOR_BLUE_PTR(prev) + ((((COLOR_RED_PTR(prev) * (COLOR_BLUE(t2) - COLOR_BLUE(t3))) + (COLOR_GREEN_PTR(prev) * (COLOR_BLUE(t1) - COLOR_BLUE(t3)))) + 0x80) >> 8);
                        COLOR_ALPHA_PTR(TEX) = COLOR_BLUE_PTR(prev) + ((((COLOR_RED_PTR(prev) * (COLOR_ALPHA(t2) - COLOR_ALPHA(t3))) + (COLOR_GREEN_PTR(prev) * (COLOR_ALPHA(t1) - COLOR_ALPHA(t3)))) + 0x80) >> 8);
                     }
                     else
                     {
-                        COLOR_RED_PTR(TEX) = COLOR_BLUE_PTR(prev) + ((((COLOR_RED_PTR(prev) * (COLOR_RED(t1) - COLOR_RED(t0))) + (COLOR_GREEN_PTR(prev) * (COLOR_RED(t2) - COLOR_RED(t0)))) + 0x80) >> 8);                                            
-                        COLOR_GREEN_PTR(TEX) = COLOR_BLUE_PTR(prev) + ((((COLOR_RED_PTR(prev) * (COLOR_GREEN(t1) - COLOR_GREEN(t0))) + (COLOR_GREEN_PTR(prev) * (COLOR_GREEN(t2) - COLOR_GREEN(t0)))) + 0x80) >> 8);                                            
-                        COLOR_BLUE_PTR(TEX) = COLOR_BLUE_PTR(prev) + ((((COLOR_RED_PTR(prev) * (COLOR_BLUE(t1) - COLOR_BLUE(t0))) + (COLOR_GREEN_PTR(prev) * (COLOR_BLUE(t2) - COLOR_BLUE(t0)))) + 0x80) >> 8);                                    
+                        COLOR_RED_PTR(TEX) = COLOR_BLUE_PTR(prev) + ((((COLOR_RED_PTR(prev) * (COLOR_RED(t1) - COLOR_RED(t0))) + (COLOR_GREEN_PTR(prev) * (COLOR_RED(t2) - COLOR_RED(t0)))) + 0x80) >> 8);
+                        COLOR_GREEN_PTR(TEX) = COLOR_BLUE_PTR(prev) + ((((COLOR_RED_PTR(prev) * (COLOR_GREEN(t1) - COLOR_GREEN(t0))) + (COLOR_GREEN_PTR(prev) * (COLOR_GREEN(t2) - COLOR_GREEN(t0)))) + 0x80) >> 8);
+                        COLOR_BLUE_PTR(TEX) = COLOR_BLUE_PTR(prev) + ((((COLOR_RED_PTR(prev) * (COLOR_BLUE(t1) - COLOR_BLUE(t0))) + (COLOR_GREEN_PTR(prev) * (COLOR_BLUE(t2) - COLOR_BLUE(t0)))) + 0x80) >> 8);
                         COLOR_ALPHA_PTR(TEX) = COLOR_BLUE_PTR(prev) + ((((COLOR_RED_PTR(prev) * (COLOR_ALPHA(t1) - COLOR_ALPHA(t0))) + (COLOR_GREEN_PTR(prev) * (COLOR_ALPHA(t2) - COLOR_ALPHA(t0)))) + 0x80) >> 8);
-                    }    
+                    }
                 }
             }
             else
@@ -3789,16 +3790,16 @@ static void texture_pipeline_cycle(COLOR* TEX, COLOR* prev, int32_t SSS, int32_t
                   sfrac <<= 2;
                   tfrac <<= 2;
 
-                  COLOR_RED_PTR(TEX) = COLOR_RED(t0) + ((((sfrac * (COLOR_RED(t1) - COLOR_RED(t0))) + (tfrac * (COLOR_RED(t2) - COLOR_RED(t0)))) + ((invt0r + COLOR_RED(t3)) << 6) + 0xc0) >> 8);                                            
-                  COLOR_GREEN_PTR(TEX) = COLOR_GREEN(t0) + ((((sfrac * (COLOR_GREEN(t1) - COLOR_GREEN(t0))) + (tfrac * (COLOR_GREEN(t2) - COLOR_GREEN(t0)))) + ((invt0g + COLOR_GREEN(t3)) << 6) + 0xc0) >> 8);                                            
-                  COLOR_BLUE_PTR(TEX) = COLOR_BLUE(t0) + ((((sfrac * (COLOR_BLUE(t1) - COLOR_BLUE(t0))) + (tfrac * (COLOR_BLUE(t2) - COLOR_BLUE(t0)))) + ((invt0b + COLOR_BLUE(t3)) << 6) + 0xc0) >> 8);                                    
+                  COLOR_RED_PTR(TEX) = COLOR_RED(t0) + ((((sfrac * (COLOR_RED(t1) - COLOR_RED(t0))) + (tfrac * (COLOR_RED(t2) - COLOR_RED(t0)))) + ((invt0r + COLOR_RED(t3)) << 6) + 0xc0) >> 8);
+                  COLOR_GREEN_PTR(TEX) = COLOR_GREEN(t0) + ((((sfrac * (COLOR_GREEN(t1) - COLOR_GREEN(t0))) + (tfrac * (COLOR_GREEN(t2) - COLOR_GREEN(t0)))) + ((invt0g + COLOR_GREEN(t3)) << 6) + 0xc0) >> 8);
+                  COLOR_BLUE_PTR(TEX) = COLOR_BLUE(t0) + ((((sfrac * (COLOR_BLUE(t1) - COLOR_BLUE(t0))) + (tfrac * (COLOR_BLUE(t2) - COLOR_BLUE(t0)))) + ((invt0b + COLOR_BLUE(t3)) << 6) + 0xc0) >> 8);
                   COLOR_ALPHA_PTR(TEX) = COLOR_ALPHA(t0) + ((((sfrac * (COLOR_ALPHA(t1) - COLOR_ALPHA(t0))) + (tfrac * (COLOR_ALPHA(t2) - COLOR_ALPHA(t0)))) + ((invt0a + COLOR_ALPHA(t3)) << 6) + 0xc0) >> 8);
                }
                else
                {
-                  COLOR_RED_PTR(TEX) = COLOR_BLUE_PTR(prev) + ((((COLOR_RED_PTR(prev) * (COLOR_RED(t1) - COLOR_RED(t0))) + (COLOR_GREEN_PTR(prev) * (COLOR_RED(t2) - COLOR_RED(t0)))) + ((invt0r + COLOR_RED(t3)) << 6) + 0xc0) >> 8);                                            
-                  COLOR_GREEN_PTR(TEX) = COLOR_BLUE_PTR(prev) + ((((COLOR_RED_PTR(prev) * (COLOR_GREEN(t1) - COLOR_GREEN(t0))) + (COLOR_GREEN_PTR(prev) * (COLOR_GREEN(t2) - COLOR_GREEN(t0)))) + ((invt0g + COLOR_GREEN(t3)) << 6) + 0xc0) >> 8);                                            
-                  COLOR_BLUE_PTR(TEX) = COLOR_BLUE_PTR(prev) + ((((COLOR_RED_PTR(prev) * (COLOR_BLUE(t1) - COLOR_BLUE(t0))) + (COLOR_GREEN_PTR(prev) * (COLOR_BLUE(t2) - COLOR_BLUE(t0)))) + ((invt0b + COLOR_BLUE(t3)) << 6) + 0xc0) >> 8);                                    
+                  COLOR_RED_PTR(TEX) = COLOR_BLUE_PTR(prev) + ((((COLOR_RED_PTR(prev) * (COLOR_RED(t1) - COLOR_RED(t0))) + (COLOR_GREEN_PTR(prev) * (COLOR_RED(t2) - COLOR_RED(t0)))) + ((invt0r + COLOR_RED(t3)) << 6) + 0xc0) >> 8);
+                  COLOR_GREEN_PTR(TEX) = COLOR_BLUE_PTR(prev) + ((((COLOR_RED_PTR(prev) * (COLOR_GREEN(t1) - COLOR_GREEN(t0))) + (COLOR_GREEN_PTR(prev) * (COLOR_GREEN(t2) - COLOR_GREEN(t0)))) + ((invt0g + COLOR_GREEN(t3)) << 6) + 0xc0) >> 8);
+                  COLOR_BLUE_PTR(TEX) = COLOR_BLUE_PTR(prev) + ((((COLOR_RED_PTR(prev) * (COLOR_BLUE(t1) - COLOR_BLUE(t0))) + (COLOR_GREEN_PTR(prev) * (COLOR_BLUE(t2) - COLOR_BLUE(t0)))) + ((invt0b + COLOR_BLUE(t3)) << 6) + 0xc0) >> 8);
                   COLOR_ALPHA_PTR(TEX) = COLOR_BLUE_PTR(prev) + ((((COLOR_RED_PTR(prev) * (COLOR_ALPHA(t1) - COLOR_ALPHA(t0))) + (COLOR_GREEN_PTR(prev) * (COLOR_ALPHA(t2) - COLOR_ALPHA(t0)))) + ((invt0a + COLOR_ALPHA(t3)) << 6) + 0xc0) >> 8);
                }
             }
@@ -3817,7 +3818,7 @@ static void texture_pipeline_cycle(COLOR* TEX, COLOR* prev, int32_t SSS, int32_t
            COLOR_BLUE_PTR(TEX) = COLOR_BLUE(t0) + ((k3_tf * COLOR_RED(t0) + 0x80) >> 8);
            COLOR_ALPHA_PTR(TEX) = COLOR_BLUE(t0);
         }
-        
+
         COLOR_RED_PTR(TEX)   &= 0x1ff;
         COLOR_GREEN_PTR(TEX) &= 0x1ff;
         COLOR_BLUE_PTR(TEX)  &= 0x1ff;
@@ -3826,13 +3827,13 @@ static void texture_pipeline_cycle(COLOR* TEX, COLOR* prev, int32_t SSS, int32_t
     else
     {
         tcclamp_cycle_light(&sss1, &sst1, maxs, maxt, tilenum);
-        tcmask(&sss1, &sst1, tilenum);    
+        tcmask(&sss1, &sst1, tilenum);
 
         if (!other_modes.en_tlut)
             fetch_texel(&t0, sss1, sst1, tilenum);
         else
             fetch_texel_entlut(&t0, sss1, sst1, tilenum);
-        
+
         if (bilerp)
         {
             if (!convert)
@@ -3849,7 +3850,7 @@ static void texture_pipeline_cycle(COLOR* TEX, COLOR* prev, int32_t SSS, int32_t
         {
             if (convert)
                 t0 = *prev;
-            
+
             COLOR_RED_PTR(TEX) = COLOR_BLUE(t0) + ((k0_tf * COLOR_GREEN(t0) + 0x80) >> 8);
             COLOR_GREEN_PTR(TEX) = COLOR_BLUE(t0) + ((k1_tf * COLOR_RED(t0) + k2_tf * COLOR_GREEN(t0) + 0x80) >> 8);
             COLOR_BLUE_PTR(TEX) = COLOR_BLUE(t0) + ((k3_tf * COLOR_RED(t0) + 0x80) >> 8);
@@ -3870,7 +3871,7 @@ static STRICTINLINE void tc_pipeline_load(int32_t* sss, int32_t* sst, int tilenu
     sst1 = SIGN16(sst1);
     sss1 = TRELATIVE(sss1, tile[tilenum].sl);
     sst1 = TRELATIVE(sst1, tile[tilenum].tl);
-    
+
     if (!coord_quad)
     {
         sss1 = (sss1 >> 5);
@@ -3881,7 +3882,7 @@ static STRICTINLINE void tc_pipeline_load(int32_t* sss, int32_t* sst, int tilenu
         sss1 = (sss1 >> 3);
         sst1 = (sst1 >> 3);
     }
-    
+
     *sss = sss1;
     *sst = sst1;
 }
@@ -3897,7 +3898,7 @@ static INLINE void tcdiv_persp(int32_t ss, int32_t st,
       int32_t sw, int32_t* sss, int32_t* sst)
 {
    int w_carry = 0;
-   int shift; 
+   int shift;
    int tlu_rcp;
    int sprod, tprod;
    int outofbounds_s, outofbounds_t;
@@ -3975,7 +3976,7 @@ static STRICTINLINE uint32_t rightcvghex(uint32_t x, uint32_t fmask)
    return (covered & fmask);
 }
 
-static STRICTINLINE uint32_t leftcvghex(uint32_t x, uint32_t fmask) 
+static STRICTINLINE uint32_t leftcvghex(uint32_t x, uint32_t fmask)
 {
    uint32_t covered = 0xf >> (((x & 7) + 1) >> 1);
    return (covered & fmask);
@@ -4057,7 +4058,7 @@ static STRICTINLINE void compute_cvg_noflip(int32_t scanline)
 				majorcur = span[scanline].majorx[i];
 				minorcurint = minorcur >> 3;
 				majorcurint = majorcur >> 3;
-								
+
 				for (k = purgestart; k <= minorcurint; k++)
 					cvgbuf[k] &= ~fmaskshifted;
 				for (k = majorcurint; k <= purgeend; k++)
@@ -4097,7 +4098,7 @@ static STRICTINLINE uint32_t dz_compress(uint32_t value)
     return j;
 }
 
-static STRICTINLINE void z_store(uint32_t zcurpixel, uint32_t z, 
+static STRICTINLINE void z_store(uint32_t zcurpixel, uint32_t z,
       int dzpixenc)
 {
    uint16_t zval = z_com_table[z & 0x3ffff]|(dzpixenc >> 2);
@@ -4212,19 +4213,19 @@ static uint32_t z_compare(uint32_t zcurpixel, uint32_t sz, uint16_t dzpix, int d
 
        switch(other_modes.z_mode)
        {
-          case ZMODE_OPAQUE: 
+          case ZMODE_OPAQUE:
              return (max || (overflow ? infront : nearer));
-          case ZMODE_INTERPENETRATING: 
+          case ZMODE_INTERPENETRATING:
              if (!infront || !farther || !overflow)
-                return (max || (overflow ? infront : nearer)); 
+                return (max || (overflow ? infront : nearer));
              dzenc         = dz_compress(dznotshift & 0xffff);
              cvgcoeff      = ((oz >> dzenc) - (sz >> dzenc)) & 0xf;
              *curpixel_cvg = ((cvgcoeff * (*curpixel_cvg)) >> 3) & 0xf;
              return 1;
-          case ZMODE_TRANSPARENT: 
-             return (infront || max); 
-          case ZMODE_DECAL: 
-             return (farther && nearer && !max); 
+          case ZMODE_TRANSPARENT:
+             return (infront || max);
+          case ZMODE_DECAL:
+             return (farther && nearer && !max);
        }
        return 0;
     }
@@ -4342,7 +4343,7 @@ static void get_dither_noise(int x, int y, int* cdith, int* adith)
 static STRICTINLINE void get_texel1_1cycle(int32_t* s1, int32_t* t1, int32_t s, int32_t t, int32_t w, int32_t dsinc, int32_t dtinc, int32_t dwinc, int32_t scanline, SPANSIGS* sigs)
 {
     int32_t nexts, nextt, nextsw;
-    
+
     if (!sigs->endspan || !sigs->longspan || !span[scanline + 1].validline)
     {
         nextsw = (w + dwinc) >> 16;
@@ -4453,7 +4454,7 @@ static STRICTINLINE int32_t compute_lod(int32_t scurr, int32_t snext, int32_t tc
 static STRICTINLINE void tclod_tcclamp(int32_t* sss, int32_t* sst)
 {
     int32_t tempanded, temps = *sss, tempt = *sst;
-    
+
     if (!(temps & 0x40000))
     {
         if (!(temps & 0x20000))
@@ -4505,13 +4506,13 @@ static void tclod_1cycle_current(int32_t* sss, int32_t* sst, int32_t nexts, int3
     bool magnify    = false;
     bool distant    = false;
     uint32_t l_tile = 0;
-    
+
     tclod_tcclamp(sss, sst);
 
     if (other_modes.f.dolod)
     {
         int nextscan = scanline + 1;
-        
+
         if (span[nextscan].validline)
         {
             if (!sigs->endspan || !sigs->longspan)
@@ -4547,17 +4548,17 @@ static void tclod_1cycle_current(int32_t* sss, int32_t* sst, int32_t nexts, int3
         tcdiv(fars, fart, farsw, &fars, &fart);
 
         lodclamp = (fart & 0x60000) || (nextt & 0x60000) || (fars & 0x60000) || (nexts & 0x60000);
-        
+
         if (!lodclamp)
            lod = compute_lod(nexts, fars, nextt, fart, 0);
 
         lodfrac_lodtile_signals(lodclamp, lod, &l_tile, &magnify, &distant);
-    
+
         if (other_modes.tex_lod_en)
         {
             if (distant)
                 l_tile = max_level;
-            
+
             if (!other_modes.detail_tex_en || magnify)
                 *t1 = (prim_tile + l_tile) & 7;
             else
@@ -4574,7 +4575,7 @@ static void tclod_1cycle_current_simple(int32_t* sss, int32_t* sst, int32_t s, i
     bool magnify    = false;
     bool distant    = false;
     uint32_t l_tile = 0;
-    
+
     tclod_tcclamp(sss, sst);
 
     if (other_modes.f.dolod)
@@ -4588,7 +4589,7 @@ static void tclod_1cycle_current_simple(int32_t* sss, int32_t* sst, int32_t s, i
                 nextsw = (w + dwinc) >> 16;
                 nexts = (s + dsinc) >> 16;
                 nextt = (t + dtinc) >> 16;
-                
+
                 if (!(sigs->preendspan && sigs->longspan) && !(sigs->endspan && sigs->midspan))
                 {
                     farsw = (w + (dwinc << 1)) >> 16;
@@ -4633,7 +4634,7 @@ static void tclod_1cycle_current_simple(int32_t* sss, int32_t* sst, int32_t s, i
            lod = compute_lod(nexts, fars, nextt, fart, 0);
 
         lodfrac_lodtile_signals(lodclamp, lod, &l_tile, &magnify, &distant);
-    
+
         if (other_modes.tex_lod_en)
         {
             if (distant)
@@ -4654,13 +4655,13 @@ static void tclod_1cycle_next(int32_t* sss, int32_t* sst, int32_t s, int32_t t, 
     bool magnify    = false;
     bool distant    = false;
     uint32_t l_tile = 0;
-    
+
     tclod_tcclamp(sss, sst);
 
     if (other_modes.f.dolod)
     {
         int nextscan = scanline + 1;
-        
+
         if (span[nextscan].validline)
         {
             if (!sigs->nextspan)
@@ -4670,7 +4671,7 @@ static void tclod_1cycle_next(int32_t* sss, int32_t* sst, int32_t s, int32_t t, 
                     nextsw = (w + dwinc) >> 16;
                     nexts = (s + dsinc) >> 16;
                     nextt = (t + dtinc) >> 16;
-                    
+
                     if (!(sigs->preendspan && sigs->longspan) && !(sigs->endspan && sigs->midspan))
                     {
                         farsw = (w + (dwinc << 1)) >> 16;
@@ -4751,15 +4752,15 @@ static void tclod_1cycle_next(int32_t* sss, int32_t* sst, int32_t s, int32_t t, 
         tcdiv(fars, fart, farsw, &fars, &fart);
 
         lodclamp = (fart & 0x60000) || (nextt & 0x60000) || (fars & 0x60000) || (nexts & 0x60000);
-        
+
         if (!lodclamp)
            lod = compute_lod(nexts, fars, nextt, fart, 0);
-        
+
         if ((lod & 0x4000) || lodclamp)
             lod = 0x7fff;
         else if (lod < min_level)
             lod = min_level;
-                    
+
         magnify = lod < 32;
         /* min_lod is maximum 31 for detail/sharpen,
          * so applying min_lod after magnify test is fine.
@@ -4769,7 +4770,7 @@ static void tclod_1cycle_next(int32_t* sss, int32_t* sst, int32_t s, int32_t t, 
 
         *prelodfrac = ((lod << 3) >> l_tile) & 0xff;
 
-        
+
         if(!other_modes.sharpen_tex_en && !other_modes.detail_tex_en)
         {
 #ifdef OPTS_ENABLED
@@ -4855,7 +4856,7 @@ static void render_spans_1cycle_complete(int start, int end, int tilenum, int fl
 
     int prim_tile = tilenum;
     int tile1 = tilenum;
-    int newtile = tilenum; 
+    int newtile = tilenum;
     int news, newt;
 
     int i, j;
@@ -5097,7 +5098,7 @@ static void render_spans_1cycle_notexel1(int start, int end, int tilenum, int fl
         dzinc = spans_cdz = spans_d_stwz_dy[3] = 0;
     }
     dzpixenc = dz_compress(dzpix);
-                    
+
     for (i = start; i <= end; i++)
     {
        SPAN *span_ptr = &span[i];
@@ -5114,7 +5115,7 @@ static void render_spans_1cycle_notexel1(int start, int end, int tilenum, int fl
         t      = span_ptr->stwz[1];
         w      = span_ptr->stwz[2];
         z      = other_modes.z_source_sel ? primitive_z : span_ptr->stwz[3];
-        
+
         x = xendsc;
         curpixel = fb_width * i + x;
         zbcur  = zb_address + 2*curpixel;
@@ -5183,7 +5184,7 @@ static void render_spans_1cycle_notexel1(int start, int end, int tilenum, int fl
 
             get_dither_noise(x, i, &cdith, &adith);
             combiner_1cycle(adith, &curpixel_cvg);
-                
+
             fbread1_ptr(curpixel, &curpixel_memcvg);
 #ifdef EXTRALOGGING
             LOG("Pre CVG: %d, MEMCVG: %d\n", curpixel_cvg, curpixel_memcvg);
@@ -5271,7 +5272,7 @@ static void render_spans_1cycle_notex(int start, int end, int tilenum, int flip)
         dzinc = -spans_d_stwz[3];
         xinc = -1;
     }
-    
+
     if (!other_modes.z_source_sel)
         dzpix = spans_dzpix;
     else
@@ -5280,7 +5281,7 @@ static void render_spans_1cycle_notex(int start, int end, int tilenum, int flip)
         dzinc = spans_cdz = spans_d_stwz_dy[3] = 0;
     }
     dzpixenc = dz_compress(dzpix);
-                    
+
     for (i = start; i <= end; i++)
     {
        SPAN *span_ptr = &span[i];
@@ -5344,7 +5345,7 @@ static void render_spans_1cycle_notex(int start, int end, int tilenum, int flip)
 #endif
             get_dither_noise(x, i, &cdith, &adith);
             combiner_1cycle(adith, &curpixel_cvg);
-                
+
             fbread1_ptr(curpixel, &curpixel_memcvg);
             if (z_compare(zbcur, sz, dzpix, dzpixenc, &blend_en, &prewrap, &curpixel_cvg, curpixel_memcvg))
             {
@@ -5402,7 +5403,7 @@ static void tclod_2cycle_current(int32_t* sss, int32_t* sst, int32_t nexts, int3
         tcdiv(nextys, nextyt, nextysw, &nextys, &nextyt);
 
         lodclamp = (initt & 0x60000) || (nextt & 0x60000) || (inits & 0x60000) || (nexts & 0x60000) || (nextys & 0x60000) || (nextyt & 0x60000);
-        
+
         if (!lodclamp)
         {
            lod = compute_lod(inits, nexts, initt, nextt, 0);
@@ -5410,7 +5411,7 @@ static void tclod_2cycle_current(int32_t* sss, int32_t* sst, int32_t nexts, int3
         }
 
         lodfrac_lodtile_signals(lodclamp, lod, &l_tile, &magnify, &distant);
-        
+
         if (other_modes.tex_lod_en)
         {
             if (distant)
@@ -5423,7 +5424,7 @@ static void tclod_2cycle_current(int32_t* sss, int32_t* sst, int32_t nexts, int3
                 else
                     *t2 = *t1;
             }
-            else 
+            else
             {
                 if (!magnify)
                     *t1 = (prim_tile + l_tile + 1);
@@ -5473,7 +5474,7 @@ static void tclod_2cycle_current_simple(int32_t* sss, int32_t* sst, int32_t s, i
         }
 
         lodfrac_lodtile_signals(lodclamp, lod, &l_tile, &magnify, &distant);
-    
+
         if (other_modes.tex_lod_en)
         {
             if (distant)
@@ -5486,7 +5487,7 @@ static void tclod_2cycle_current_simple(int32_t* sss, int32_t* sst, int32_t s, i
                 else
                     *t2 = *t1;
             }
-            else 
+            else
             {
                 if (!magnify)
                     *t1 = (prim_tile + l_tile + 1);
@@ -5536,7 +5537,7 @@ static void tclod_2cycle_current_notexel1(int32_t* sss, int32_t* sst, int32_t s,
         }
 
         lodfrac_lodtile_signals(lodclamp, lod, &l_tile, &magnify, &distant);
-    
+
         if (other_modes.tex_lod_en)
         {
             if (distant)
@@ -5546,7 +5547,7 @@ static void tclod_2cycle_current_notexel1(int32_t* sss, int32_t* sst, int32_t s,
             else
                 *t1 = (prim_tile + l_tile + 1) & 7;
         }
-        
+
     }
 }
 
@@ -5574,7 +5575,7 @@ static void tclod_2cycle_next(int32_t* sss, int32_t* sst, int32_t s, int32_t t, 
 
         tcdiv(nexts, nextt, nextsw, &nexts, &nextt);
         tcdiv(nextys, nextyt, nextysw, &nextys, &nextyt);
-    
+
         lodclamp = (initt & 0x60000) || (nextt & 0x60000) || (inits & 0x60000) || (nexts & 0x60000) || (nextys & 0x60000) || (nextyt & 0x60000);
 
         if (!lodclamp)
@@ -5583,12 +5584,12 @@ static void tclod_2cycle_next(int32_t* sss, int32_t* sst, int32_t s, int32_t t, 
            lod = compute_lod(inits, nextys, initt, nextyt, lod);
         }
 
-        
+
         if ((lod & 0x4000) || lodclamp)
             lod = 0x7fff;
         else if (lod < min_level)
             lod = min_level;
-                        
+
         magnify = lod < 32;
         /* min_lod is maximum 31 for detail/sharpen,
          * so applying min_lod after magnify test is fine.
@@ -5598,7 +5599,7 @@ static void tclod_2cycle_next(int32_t* sss, int32_t* sst, int32_t s, int32_t t, 
 
         *prelodfrac = ((lod << 3) >> l_tile) & 0xff;
 
-        
+
         if(!other_modes.sharpen_tex_en && !other_modes.detail_tex_en)
         {
 #ifdef OPTS_ENABLED
@@ -5628,7 +5629,7 @@ static void tclod_2cycle_next(int32_t* sss, int32_t* sst, int32_t s, int32_t t, 
                 else
                     *t2 = *t1;
             }
-            else 
+            else
             {
                 if (!magnify)
                     *t1 = (prim_tile + l_tile + 1);
@@ -5675,7 +5676,7 @@ static void render_spans_2cycle_complete(int start, int end, int tilenum, int fl
     int xstart, xend, xendsc;
     int sss = 0, sst = 0;
     int curpixel = 0;
-    
+
     int x, length, scdiff;
     uint32_t fir, fig, fib;
 
@@ -5715,7 +5716,7 @@ static void render_spans_2cycle_complete(int start, int end, int tilenum, int fl
         dzinc = spans_cdz = spans_d_stwz_dy[3] = 0;
     }
     dzpixenc = dz_compress(dzpix);
-                
+
     for (i = start; i <= end; i++)
     {
         if (span[i].validline == 0)
@@ -5817,7 +5818,7 @@ static void render_spans_2cycle_complete(int start, int end, int tilenum, int fl
                     fbwrite_ptr(curpixel, fir, fig, fib, blend_en, curpixel_cvg, curpixel_memcvg);
                     if (other_modes.z_update_en)
                         z_store(zbcur, sz, dzpixenc);
-                    
+
                 }
             }
             else
@@ -5830,7 +5831,7 @@ static void render_spans_2cycle_complete(int start, int end, int tilenum, int fl
             b += dbinc;
             a += dainc;
             z += dzinc;
-            
+
             x += xinc;
             curpixel += xinc;
             zbcur += xinc;
@@ -5863,7 +5864,7 @@ static void render_spans_2cycle_notexelnext(int start, int end, int tilenum, int
     int xstart, xend, xendsc;
     int sss = 0, sst = 0;
     int curpixel = 0;
-    
+
     int x, length, scdiff;
     uint32_t fir, fig, fib;
 
@@ -5903,7 +5904,7 @@ static void render_spans_2cycle_notexelnext(int start, int end, int tilenum, int
         dzinc = spans_cdz = spans_d_stwz_dy[3] = 0;
     }
     dzpixenc = dz_compress(dzpix);
-                
+
     for (i = start; i <= end; i++)
     {
         if (span[i].validline == 0)
@@ -5964,11 +5965,11 @@ static void render_spans_2cycle_notexelnext(int start, int end, int tilenum, int
             sz = (z >> 10) & 0x3fffff;
 
             lookup_cvmask_derivatives(cvgbuf[x], &offx, &offy, &curpixel_cvg, &curpixel_cvbit);
-            
+
             tcdiv(ss, st, sw, &sss, &sst);
 
             tclod_2cycle_current_simple(&sss, &sst, s, t, w, dsinc, dtinc, dwinc, prim_tile, &tile1, &tile2);
-                
+
             texture_pipeline_cycle(&texel0_color, &texel0_color, sss, sst, tile1, 0);
             texture_pipeline_cycle(&texel1_color, &texel0_color, sss, sst, tile2, 1);
 
@@ -5978,10 +5979,10 @@ static void render_spans_2cycle_notexelnext(int start, int end, int tilenum, int
 #endif
 
             rgbaz_correct_clip(offx, offy, sr, sg, sb, sa, &sz, curpixel_cvg);
-                    
+
             get_dither_noise(x, i, &cdith, &adith);
             combiner_2cycle(adith, &curpixel_cvg, &acalpha);
-                
+
             fbread2_ptr(curpixel, &curpixel_memcvg);
 
             if (z_compare(zbcur, sz, dzpix, dzpixenc, &blend_en, &prewrap, &curpixel_cvg, curpixel_memcvg))
@@ -6006,7 +6007,7 @@ static void render_spans_2cycle_notexelnext(int start, int end, int tilenum, int
             b += dbinc;
             a += dainc;
             z += dzinc;
-            
+
             x += xinc;
             curpixel += xinc;
             zbcur += xinc;
@@ -6045,7 +6046,7 @@ static void render_spans_2cycle_notexel1(int start, int end, int tilenum, int fl
     int xstart, xend, xendsc;
     int sss = 0, sst = 0;
     int curpixel = 0;
-    
+
     int x, length, scdiff;
     uint32_t fir, fig, fib;
 
@@ -6146,12 +6147,12 @@ static void render_spans_2cycle_notexel1(int start, int end, int tilenum, int fl
             sz = (z >> 10) & 0x3fffff;
 
             lookup_cvmask_derivatives(cvgbuf[x], &offx, &offy, &curpixel_cvg, &curpixel_cvbit);
-            
+
             tcdiv(ss, st, sw, &sss, &sst);
 
             tclod_2cycle_current_notexel1(&sss, &sst, s, t, w, dsinc, dtinc, dwinc, prim_tile, &tile1);
-            
-            
+
+
             texture_pipeline_cycle(&texel0_color, &texel0_color, sss, sst, tile1, 0);
 
 #ifdef EXTRALOGGING
@@ -6164,10 +6165,10 @@ static void render_spans_2cycle_notexel1(int start, int end, int tilenum, int fl
 #ifdef EXTRALOGGING
             LOG("SZ = %d\n", sz);
 #endif
-                    
+
             get_dither_noise(x, i, &cdith, &adith);
             combiner_2cycle(adith, &curpixel_cvg, &acalpha);
-                
+
             fbread2_ptr(curpixel, &curpixel_memcvg);
 
             if (z_compare(zbcur, sz, dzpix, dzpixenc, &blend_en, &prewrap, &curpixel_cvg, curpixel_memcvg))
@@ -6200,7 +6201,7 @@ static void render_spans_2cycle_notexel1(int start, int end, int tilenum, int fl
             b += dbinc;
             a += dainc;
             z += dzinc;
-            
+
             x += xinc;
             curpixel += xinc;
             zbcur += xinc;
@@ -6230,7 +6231,7 @@ static void render_spans_2cycle_notex(int start, int end, int tilenum, int flip)
     int sr, sg, sb, sa, sz;
     int xstart, xend, xendsc;
     int curpixel = 0;
-    
+
     int x, length, scdiff;
     uint32_t fir, fig, fib;
 
@@ -6264,7 +6265,7 @@ static void render_spans_2cycle_notex(int start, int end, int tilenum, int flip)
         dzinc = spans_cdz = spans_d_stwz_dy[3] = 0;
     }
     dzpixenc = dz_compress(dzpix);
-                
+
     for (i = start; i <= end; i++)
     {
         if (span[i].validline == 0)
@@ -6318,10 +6319,10 @@ static void render_spans_2cycle_notex(int start, int end, int tilenum, int flip)
             lookup_cvmask_derivatives(cvgbuf[x], &offx, &offy, &curpixel_cvg, &curpixel_cvbit);
 
             rgbaz_correct_clip(offx, offy, sr, sg, sb, sa, &sz, curpixel_cvg);
-                    
+
             get_dither_noise(x, i, &cdith, &adith);
             combiner_2cycle(adith, &curpixel_cvg, &acalpha);
-                
+
             fbread2_ptr(curpixel, &curpixel_memcvg);
 
             if (z_compare(zbcur, sz, dzpix, dzpixenc, &blend_en, &prewrap, &curpixel_cvg, curpixel_memcvg))
@@ -6343,7 +6344,7 @@ static void render_spans_2cycle_notex(int start, int end, int tilenum, int flip)
             b += dbinc;
             a += dainc;
             z += dzinc;
-            
+
             x += xinc;
             curpixel += xinc;
             zbcur += xinc;
@@ -6585,7 +6586,7 @@ static void tclod_copy(int32_t* sss, int32_t* sst, int32_t s, int32_t t, int32_t
         farsw = (w + (dwinc << 1)) >> 16;
         fars = (s + (dsinc << 1)) >> 16;
         fart = (t + (dtinc << 1)) >> 16;
-    
+
         tcdiv(nexts, nextt, nextsw, &nexts, &nextt);
         tcdiv(fars, fart, farsw, &fars, &fart);
 
@@ -6598,7 +6599,7 @@ static void tclod_copy(int32_t* sss, int32_t* sst, int32_t s, int32_t t, int32_t
             lod = 0x7fff;
         else if (lod < min_level)
             lod = min_level;
-                        
+
         magnify = lod < 32;
         /* min_lod is maximum 31 for detail/sharpen,
          * so applying min_lod after magnify test is fine.
@@ -6608,7 +6609,7 @@ static void tclod_copy(int32_t* sss, int32_t* sst, int32_t s, int32_t t, int32_t
 
         if (distant)
             l_tile = max_level;
-    
+
         if (!other_modes.detail_tex_en || magnify)
             *t1 = (prim_tile + l_tile) & 7;
         else
@@ -6619,7 +6620,7 @@ static void tclod_copy(int32_t* sss, int32_t* sst, int32_t s, int32_t t, int32_t
 static void render_spans_copy(int start, int end, int tilenum, int flip)
 {
     int i, j, k;
-    
+
     int tile1 = tilenum;
     int prim_tile = tilenum;
 
@@ -6665,7 +6666,7 @@ static void render_spans_copy(int start, int end, int tilenum, int flip)
     }
 
 #define PIXELS_TO_BYTES_SPECIAL4(pix, siz) ((siz) ? PIXELS_TO_BYTES(pix, siz) : (pix))
-                
+
     for (i = start; i <= end; i++)
     {
         if (span[i].validline == 0)
@@ -6673,7 +6674,7 @@ static void render_spans_copy(int start, int end, int tilenum, int flip)
         s = span[i].stwz[0];
         t = span[i].stwz[1];
         w = span[i].stwz[2];
-        
+
         xstart = span[i].lx;
         xendsc = span[i].rx;
 
@@ -6721,7 +6722,7 @@ static void render_spans_copy(int start, int end, int tilenum, int flip)
                     currthreshold = ((threshold & 0xf) << 4) | (threshold >> 4);
                     alphamask |= (((copyqword >> 8) & 0xff) >= currthreshold ? 0xC : 0);
                     currthreshold = ((threshold & 0x3f) << 2) | (threshold >> 6);
-                    alphamask |= ((copyqword & 0xff) >= currthreshold ? 0x3 : 0);    
+                    alphamask |= ((copyqword & 0xff) >= currthreshold ? 0x3 : 0);
                 }
                 else
                 {
@@ -6738,7 +6739,7 @@ static void render_spans_copy(int start, int end, int tilenum, int flip)
             copywmask ^= -flip;
             copywmask -= -flip;
             copywmask += bytesperpixel;
-            if (copywmask > 8) 
+            if (copywmask > 8)
                 copywmask = 8;
             tempdword = fbptr;
             k = 7;
@@ -6792,25 +6793,25 @@ static void deduce_derivatives(void)
         lod_frac_used_in_cc0 = 1;
 
     if (combiner_rgbmul_r[1] == &COLOR_RED(texel1_color) || combiner_rgbsub_a_r[1] == &COLOR_RED(texel1_color) || combiner_rgbsub_b_r[1] == &COLOR_RED(texel1_color) || combiner_rgbadd_r[1] == &COLOR_RED(texel1_color) ||
-        combiner_alphamul[1] == &COLOR_ALPHA(texel1_color) || combiner_alphasub_a[1] == &COLOR_ALPHA(texel1_color) || combiner_alphasub_b[1] == &COLOR_ALPHA(texel1_color) || combiner_alphaadd[1] == &COLOR_ALPHA(texel1_color) || 
+        combiner_alphamul[1] == &COLOR_ALPHA(texel1_color) || combiner_alphasub_a[1] == &COLOR_ALPHA(texel1_color) || combiner_alphasub_b[1] == &COLOR_ALPHA(texel1_color) || combiner_alphaadd[1] == &COLOR_ALPHA(texel1_color) ||
         combiner_rgbmul_r[1] == &COLOR_ALPHA(texel1_color))
         texel1_used_in_cc1 = 1;
-    if (combiner_rgbmul_r[1] == &COLOR_RED(texel0_color) || combiner_rgbsub_a_r[1] == &COLOR_RED(texel0_color) || combiner_rgbsub_b_r[1] == &COLOR_RED(texel0_color) || combiner_rgbadd_r[1] == &COLOR_RED(texel0_color) || 
-        combiner_alphamul[1] == &COLOR_ALPHA(texel0_color) || combiner_alphasub_a[1] == &COLOR_ALPHA(texel0_color) || combiner_alphasub_b[1] == &COLOR_ALPHA(texel0_color) || combiner_alphaadd[1] == &COLOR_ALPHA(texel0_color) || 
+    if (combiner_rgbmul_r[1] == &COLOR_RED(texel0_color) || combiner_rgbsub_a_r[1] == &COLOR_RED(texel0_color) || combiner_rgbsub_b_r[1] == &COLOR_RED(texel0_color) || combiner_rgbadd_r[1] == &COLOR_RED(texel0_color) ||
+        combiner_alphamul[1] == &COLOR_ALPHA(texel0_color) || combiner_alphasub_a[1] == &COLOR_ALPHA(texel0_color) || combiner_alphasub_b[1] == &COLOR_ALPHA(texel0_color) || combiner_alphaadd[1] == &COLOR_ALPHA(texel0_color) ||
         combiner_rgbmul_r[1] == &COLOR_ALPHA(texel0_color))
         texel0_used_in_cc1 = 1;
-    if (combiner_rgbmul_r[0] == &COLOR_RED(texel1_color) || combiner_rgbsub_a_r[0] == &COLOR_RED(texel1_color) || combiner_rgbsub_b_r[0] == &COLOR_RED(texel1_color) || combiner_rgbadd_r[0] == &COLOR_RED(texel1_color) || 
+    if (combiner_rgbmul_r[0] == &COLOR_RED(texel1_color) || combiner_rgbsub_a_r[0] == &COLOR_RED(texel1_color) || combiner_rgbsub_b_r[0] == &COLOR_RED(texel1_color) || combiner_rgbadd_r[0] == &COLOR_RED(texel1_color) ||
         combiner_alphamul[0] == &COLOR_ALPHA(texel1_color) || combiner_alphasub_a[0] == &COLOR_ALPHA(texel1_color) || combiner_alphasub_b[0] == &COLOR_ALPHA(texel1_color) || combiner_alphaadd[0] == &COLOR_ALPHA(texel1_color) ||
         combiner_rgbmul_r[0] == &COLOR_ALPHA(texel1_color))
         texel1_used_in_cc0 = 1;
-    if (combiner_rgbmul_r[0] == &COLOR_RED(texel0_color) || combiner_rgbsub_a_r[0] == &COLOR_RED(texel0_color) || combiner_rgbsub_b_r[0] == &COLOR_RED(texel0_color) || combiner_rgbadd_r[0] == &COLOR_RED(texel0_color) || 
-        combiner_alphamul[0] == &COLOR_ALPHA(texel0_color) || combiner_alphasub_a[0] == &COLOR_ALPHA(texel0_color) || combiner_alphasub_b[0] == &COLOR_ALPHA(texel0_color) || combiner_alphaadd[0] == &COLOR_ALPHA(texel0_color) || 
+    if (combiner_rgbmul_r[0] == &COLOR_RED(texel0_color) || combiner_rgbsub_a_r[0] == &COLOR_RED(texel0_color) || combiner_rgbsub_b_r[0] == &COLOR_RED(texel0_color) || combiner_rgbadd_r[0] == &COLOR_RED(texel0_color) ||
+        combiner_alphamul[0] == &COLOR_ALPHA(texel0_color) || combiner_alphasub_a[0] == &COLOR_ALPHA(texel0_color) || combiner_alphasub_b[0] == &COLOR_ALPHA(texel0_color) || combiner_alphaadd[0] == &COLOR_ALPHA(texel0_color) ||
         combiner_rgbmul_r[0] == &COLOR_ALPHA(texel0_color))
         texel0_used_in_cc0 = 1;
     texels_in_cc0 = texel0_used_in_cc0 || texel1_used_in_cc0;
-    texels_in_cc1 = texel0_used_in_cc1 || texel1_used_in_cc1;    
+    texels_in_cc1 = texel0_used_in_cc1 || texel1_used_in_cc1;
 
-    
+
     if (texel1_used_in_cc1)
         render_spans_1cycle_ptr = render_spans_1cycle_func[2];
     else if (texel0_used_in_cc1 || lod_frac_used_in_cc1)
@@ -7020,7 +7021,7 @@ static NOINLINE void loading_pipeline(
                 break;
             }
 
-            
+
             switch(tmem_formatting)
             {
             case 0:
@@ -7121,9 +7122,9 @@ static void edgewalker_for_loads(int32_t* lewdata)
 
     int tilenum     = (lewdata[0] >> 16) & 7;
 
-    int32_t yl      = SIGN(lewdata[0], 14); 
+    int32_t yl      = SIGN(lewdata[0], 14);
     int32_t ym      = lewdata[1] >> 16;
-    int32_t yh      = SIGN(lewdata[1], 14); 
+    int32_t yh      = SIGN(lewdata[1], 14);
     int32_t xl      = SIGN(lewdata[2], 30);
     int32_t xh      = SIGN(lewdata[3], 30);
     int32_t xm      = SIGN(lewdata[4], 30);
@@ -7523,7 +7524,7 @@ static void fbread_32(uint32_t curpixel, uint32_t* curpixel_memcvg)
 
 static void fbread2_32(uint32_t curpixel, uint32_t* curpixel_memcvg)
 {
-   uint32_t addr      = ((fb_address >> 2) + curpixel) & (RDRAM_MASK >> 2); 
+   uint32_t addr      = ((fb_address >> 2) + curpixel) & (RDRAM_MASK >> 2);
    uint32_t mem       = (addr <= IDXLIM32) ? rdram[addr] : 0;
 
    COLOR_RED(pre_memory_color)    = (mem >> 24) & 0xFF;
@@ -8621,7 +8622,7 @@ static NOINLINE void draw_texture_rectangle(
         else
         {
            bool curcross = false;
-           invaly        = (uint32_t)(k - yhlimit)>>31 
+           invaly        = (uint32_t)(k - yhlimit)>>31
               | (uint32_t)~(k - yllimit)>>31;
 
            j = k >> 2;
@@ -8939,7 +8940,7 @@ static void load_tile(uint32_t w1, uint32_t w2)
 static void set_tile(uint32_t w1, uint32_t w2)
 {
     const int tilenum     = (w2 & 0x07000000) >> 24;
-    
+
     tile[tilenum].format  = (w1 & 0x00E00000) >> (53 - 32);
     tile[tilenum].size    = (w1 & 0x00180000) >> (51 - 32);
     tile[tilenum].line    = (w1 & 0x0003FE00) >> (41 - 32);
@@ -9209,5 +9210,3 @@ static void set_color_image(uint32_t w1, uint32_t w2)
     ++fb_width;
     /* fb_address &= 0x00FFFFFF; */
 }
-
-


### PR DESCRIPTION
Doesn't actually work though because of coroutines.

Important changes:
* Fix function signatures not always matching. (Emscripten complains about this a lot.)
* Update resampler code to newer version so static compiles work.
* Remove ugly static compile hacks from Emscripten makefile rules.
* Fix what looks like a bug in rglBlendFuncSeparate. (It was calling the normal glBlendFunc instead?)