### PR TITLE
Refactor android jni makefiles

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -1,140 +1,52 @@
 LOCAL_PATH := $(call my-dir)
-PERFTEST = 0
-HAVE_RDP_DUMP=0
-HAVE_RSP_DUMP=0
-HAVE_HWFBE = 0
-HAVE_SHARED_CONTEXT=0
-HAVE_OPENGL=1
-GLES = 1
-HAVE_RSP_DUMP=0
-WITH_DYNAREC :=
-COMMON_FLAGS :=
-HAVE_PARALLEL := 0
-HAVE_THR_AL := 0
-HAVE_NEON := 0
 
-include $(CLEAR_VARS)
+ROOT_DIR      := $(LOCAL_PATH)/..
+LIBRETRO_DIR  := $(ROOT_DIR)/libretro
 
-GIT_VERSION ?= " $(shell git rev-parse --short HEAD || echo unknown)"
-ifneq ($(GIT_VERSION)," unknown")
-	LOCAL_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+SOURCES_C     :=
+SOURCES_CXX   :=
+SOURCES_ASM   :=
+INCFLAGS      :=
+CFLAGS        :=
+CXXFLAGS      :=
+DYNAFLAGS     :=
+HAVE_NEON     := 0
+WITH_DYNAREC  :=
+
+HAVE_OPENGL   := 1
+GLES          := 1
+HAVE_PARALLEL := 1
+HAVE_THR_AL   := 1
+
+ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
+  WITH_DYNAREC := arm64
+else ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
+  WITH_DYNAREC := arm
+  HAVE_NEON := 1
+else ifeq ($(TARGET_ARCH_ABI),x86)
+  # X86 dynarec isn't position independent, so it will not run on api 23+
+  # This core uses vulkan which is api 24+, so dynarec cannot be used
+  WITH_DYNAREC := bogus
+else ifeq ($(TARGET_ARCH_ABI),x86_64)
+  WITH_DYNAREC := x86_64
 endif
-
-LOCAL_MODULE := retro
-
-ROOT_DIR := ..
-LIBRETRO_DIR = ../libretro
-
-ifeq ($(TARGET_ARCH),arm64)
-WITH_DYNAREC := arm64
-HAVE_PARALLEL :=1
-endif
-
-ifeq ($(TARGET_ARCH),arm)
-LOCAL_ARM_MODE := arm
-LOCAL_CFLAGS := -marm
-WITH_DYNAREC := arm
-
-COMMON_FLAGS := -DANDROID_ARM -DDYNAREC -DNEW_DYNAREC=3 -DNO_ASM
-WITH_DYNAREC := arm
-
-ifeq ($(TARGET_ARCH_ABI), armeabi-v7a)
-LOCAL_ARM_NEON := true
-HAVE_PARALLEL :=1
-HAVE_THR_AL := 1
-HAVE_NEON := 1
-endif
-
-ifeq ($(TARGET_ARCH_ABI), armeabi-v7a-hard)
-LOCAL_ARM_NEON := true
-HAVE_PARALLEL :=1
-HAVE_THR_AL := 1
-HAVE_NEON := 1
-endif
-
-ifeq ($(HAVE_NEON), 1)
-ifeq ($(USE_SSE2NEON), 1)
-COMMON_FLAGS += -DUSE_SSE2NEON
-endif
-endif
-
-endif
-
-ifeq ($(TARGET_ARCH),x86)
-HAVE_PARALLEL :=1
-HAVE_THR_AL := 1
-COMMON_FLAGS := -DANDROID_X86 -DDYNAREC -D__SSE2__ -D__SSE__ -D__SOFTFP__
-WITH_DYNAREC := x86
-endif
-
-ifeq ($(TARGET_ARCH),x86_64)
-HAVE_PARALLEL :=1
-HAVE_THR_AL := 1
-COMMON_FLAGS := -DANDROID_X86 -DDYNAREC -D__SSE2__ -D__SSE__ -D__SOFTFP__
-WITH_DYNAREC := x86_64
-endif
-
-ifeq ($(TARGET_ARCH),mips)
-COMMON_FLAGS := -DANDROID_MIPS
-endif
-
-ifeq ($(NDK_TOOLCHAIN_VERSION), 4.6)
-COMMON_FLAGS += -DANDROID_OLD_GCC
-endif
-
-SOURCES_C   :=
-SOURCES_CXX :=
-SOURCES_ASM :=
-INCFLAGS    :=
 
 include $(ROOT_DIR)/Makefile.common
 
-LOCAL_SRC_FILES := $(SOURCES_CXX) $(SOURCES_C) $(SOURCES_ASM)
+COREFLAGS := -ffast-math -DM64P_CORE_PROTOTYPES -D_ENDUSER_RELEASE -DM64P_PLUGIN_API -D__LIBRETRO__ -DINLINE="inline" -DANDROID $(GLFLAGS) $(INCFLAGS) $(DYNAFLAGS)
 
-# Video Plugins
-
-ifeq ($(HAVE_HWFBE), 1)
-COMMON_FLAGS += -DHAVE_HWFBE
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+  COREFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
 endif
 
-ifeq ($(HAVE_SHARED_CONTEXT), 1)
-COMMON_FLAGS += -DHAVE_SHARED_CONTEXT
-endif
-
-PLATFORM_EXT := unix
-
-ifeq ($(GLIDE64MK2),1)
-COMMON_FLAGS += -DGLIDE64_MK2
-endif
-
-ifeq ($(HAVE_OPENGL),1)
-COMMON_FLAGS += -DHAVE_OPENGLES -DHAVE_OPENGLES2
-endif
-
-COMMON_FLAGS += -DM64P_CORE_PROTOTYPES -D_ENDUSER_RELEASE -DM64P_PLUGIN_API -D__LIBRETRO__ -DINLINE="inline" -DANDROID -DSINC_LOWER_QUALITY -DHAVE_LOGGER -fexceptions $(GLFLAGS)
-COMMON_OPTFLAGS = -O3 -ffast-math
-
-LOCAL_CFLAGS += $(COMMON_OPTFLAGS)   $(CFLAGS)   $(COMMON_FLAGS) $(INCFLAGS)
-LOCAL_CXXFLAGS += $(COMMON_OPTFLAGS) $(CXXFLAGS) $(COMMON_FLAGS) $(INCFLAGS)
-
-ifeq ($(HAVE_PARALLEL),1)
-LOCAL_CXXFLAGS += -std=c++11
-LOCAL_CXXFLAGS += -DHAVE_PARALLEL
-LOCAL_CFLAGS += -DHAVE_PARALLEL
-endif
-
-ifeq ($(HAVE_THR_AL),1)
-LOCAL_CXXFLAGS += -DHAVE_THR_AL
-LOCAL_CFLAGS += -DHAVE_THR_AL
-endif
-
-LOCAL_LDLIBS += -lGLESv2
-LOCAL_C_INCLUDES = $(CORE_DIR)/src $(CORE_DIR)/src/api $(VIDEODIR_GLIDE)/Glitch64/inc $(LIBRETRO_DIR)/libco $(LIBRETRO_DIR)
-LOCAL_LDFLAGS := -Wl,-Bsymbolic -shared
-
-ifeq ($(PERFTEST), 1)
-LOCAL_CFLAGS += -DPERF_TEST
-LOCAL_CXXFLAGS += -DPERF_TEST
-endif
-
+include $(CLEAR_VARS)
+LOCAL_MODULE       := retro
+LOCAL_SRC_FILES    := $(SOURCES_CXX) $(SOURCES_C) $(SOURCES_ASM)
+LOCAL_CFLAGS       := $(COREFLAGS) $(CFLAGS)
+LOCAL_CXXFLAGS     := -std=c++11 $(COREFLAGS) $(CXXFLAGS)
+LOCAL_LDFLAGS      := -Wl,-version-script=$(LIBRETRO_DIR)/link.T
+LOCAL_LDLIBS       := -lGLESv2
+LOCAL_CPP_FEATURES := exceptions
+LOCAL_ARM_NEON     := true
 include $(BUILD_SHARED_LIBRARY)

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,3 +1,3 @@
 APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_STL := gnustl_static
-
+APP_PLATFORM := android-24


### PR DESCRIPTION
This raises the android api level to 24, which was when vulkan was implemented in aosp.
The x86 dynarec is not pic compliant, which is required since api 23, so android x86 builds are interpreter only.