### PR TITLE
add reference for operator=

### DIFF
--- a/gles2rice/src/IColor.h
+++ b/gles2rice/src/IColor.h
@@ -44,13 +44,13 @@ public:
         *((COLOR*)this) = (unsigned int) rgba;
     }
 
-    inline IColor operator = (const IColor &sec) const
+    inline IColor &operator = (const IColor &sec) const
     {
         *((COLOR*)this) = *((COLOR*)&sec);
         return *this;
     }
 
-    inline IColor operator = (COLOR col) const
+    inline IColor &operator = (COLOR col) const
     {
         *((COLOR*)this) = col;
         return *this;


### PR DESCRIPTION
Hi all,
There is a non-reference operator= found by Qihoo360 CodeSafe Team.
Details as bellow:

operaotr= without reference will call a redundant copy constructor function.

Cheers
Qihoo360 CodeSafe Team