### PR TITLE
Adding the 4:3 resolution of 1440x1080

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -338,7 +338,7 @@ static void setup_variables(void)
 #endif
          },
       { "parallel-n64-screensize",
-         "Resolution (restart); 640x480|960x720|1280x960|1600x1200|1920x1440|2240x1680|320x240" },
+         "Resolution (restart); 640x480|960x720|1280x960|1440x1080|1600x1200|1920x1440|2240x1680|320x240" },
       { "parallel-n64-aspectratiohint",
          "Aspect ratio hint (reinit); normal|widescreen" },
       { "parallel-n64-filtering",


### PR DESCRIPTION
On 1080p monitors this 4:3 resolution of 1440x1080 is quite beneficial compared to it's closest neighbor 1280x960, because this resolution gets rid of the black borders on the upper- and lower part of the image itself.