### PR TITLE
Added 4:3 resolution for 4K & 8K screens

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -338,7 +338,7 @@ static void setup_variables(void)
 #endif
          },
       { "parallel-n64-screensize",
-         "Resolution (restart); 640x480|960x720|1280x960|1440x1080|1600x1200|1920x1440|2240x1680|320x240" },
+         "Resolution (restart); 640x480|960x720|1280x960|1440x1080|1600x1200|1920x1440|2240x1680|2880x2160|5760x4320|320x240" },
       { "parallel-n64-aspectratiohint",
          "Aspect ratio hint (reinit); normal|widescreen" },
       { "parallel-n64-filtering",


### PR DESCRIPTION
There are probably users with 4K screens (3840x2160) using libretro/RetroArch now, and in a near future users with even 8K screens (7680x4320).

I used some online aspect ratio calculators to find the 4:3 variant of those 16:9 resolutions (as the 4:3 aspect ratio is most common in N64 games). The 4:3 variant of 4K is 2880x2160, and the 4:3 variant of 8K is 5760x4320.