### PR TITLE
Backport fix to VRCPL and VRSQL to pass hardware tests.

### DIFF
--- a/mupen64plus-rsp-cxd4/vu/divide.c
+++ b/mupen64plus-rsp-cxd4/vu/divide.c
@@ -1,7 +1,7 @@
 /******************************************************************************\
 * Project:  MSP Simulation Layer for Vector Unit Computational Divides         *
 * Authors:  Iconoclast                                                         *
-* Release:  2016.03.23                                                         *
+* Release:  2018.11.25                                                         *
 * License:  CC0 Public Domain Dedication                                       *
 *                                                                              *
 * To the extent possible under law, the author(s) have dedicated all copyright *
@@ -1156,8 +1156,10 @@ VECTOR_OPERATION VRCPL(v16 vs, v16 vt)
     const int target = (inst_word >> 16) & 31;
     const unsigned int element = (inst_word >> 21) & 0x7;
 
-    DivIn &= DPH;
-    DivIn |= (u16)VR[target][element];
+    if (DPH == SP_DIV_PRECISION_SINGLE)
+        DivIn  = (s32)(s16)(VR[target][element]);
+    else
+        DivIn |= (s32)(u16)(VR[target][element] & 0xFFFFu);
     do_div(DivIn, SP_DIV_SQRT_NO, DPH);
 #ifdef ARCH_MIN_SSE2
     *(v16 *)VACC_L = vt;
@@ -1260,8 +1262,10 @@ VECTOR_OPERATION VRSQL(v16 vs, v16 vt)
     const int target = (inst_word >> 16) & 31;
     const unsigned int element = (inst_word >> 21) & 0x7;
 
-    DivIn &= DPH;
-    DivIn |= (u16)VR[target][element];
+    if (DPH == SP_DIV_PRECISION_SINGLE)
+        DivIn  = (s32)(s16)(VR[target][element]);
+    else
+        DivIn |= (s32)(u16)(VR[target][element] & 0xFFFFu);
     do_div(DivIn, SP_DIV_SQRT_YES, DPH);
 #ifdef ARCH_MIN_SSE2
     *(v16 *)VACC_L = vt;


### PR DESCRIPTION
Long time, no update from me I guess.  My bad...got carried away and busy and lazy at the same time I guess.  Still need to get RetroArch cloned to this newer computer so I can start testing on here instead of just my old 64-bit Mupen64 when I get a chance.

This is a backport of the following commit also made upstream today:
https://github.com/cxd4/rsp/commit/1f7c9fdc0fb811ee928eba6a250b3743f8ff3c9c

I made that commit in response to a contribution made by someone which showed me my RSP plugin was failing a couple tests on real hardware that games weren't exploiting (as far as I could tell):
https://github.com/cxd4/rsp/pull/17

What I got wrong was that if a N64 program purposely tries to do a pointless divide scheme which contradicts itself (i.e. VRCP followed by VRCPL/VRSQL or VRSQ followed by VRSQL/VRCPL), the division input temporary should be reset with a single-precision assignment (16 bits signed to a 32-bit cast) because using VRCPL without executing VRCPH--**not VRCP**--first is pointless.

So commercial games would never do this I believe (though we can wait and see on that some more), but this is a technical op-code accuracy bug fix in the case that the RSP microcode is done in a way that uses self-defeating division, so to speak.

I'll wait until after the one who brought the discussion up originally confirms the fix and says he's happy before I merge my own commit here.