### PR TITLE
Fix build with clang.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -820,7 +820,9 @@ ifneq ($(findstring Darwin,$(UNAME)),)
    CPUOPTS += -flto
 else ifeq ($(findstring msvc,$(platform)),)
 ifneq ($(platform), emscripten)
+ifneq ($(shell $(CC) -v 2>&1 | grep -c "clang"),1)
    CPUOPTS += -fipa-pta
+endif
 endif
 endif
 


### PR DESCRIPTION
The build with `clang-8.0.0` fails.
```
clang-8: error: unknown argument: '-fipa-pta'
```