### PR TITLE
Fix musl build, stderr is in stdio.h

### DIFF
--- a/mupen64plus-video-paraLLEl/rdp/rdp.hpp
+++ b/mupen64plus-video-paraLLEl/rdp/rdp.hpp
@@ -7,6 +7,7 @@
 #include <stdint.h>
 #include <unordered_map>
 #include <cstring>
+#include <cstdio>
 #include <vector>
 
 #define RDP_MAX_PRIMITIVES 	1024


### PR DESCRIPTION
`fprintf` and `stderr` are defined in *stdio.h* as specified by [C standard](https://en.cppreference.com/w/c/io). On musl system parallel-n64 could not build because this header was not implicitly included.