### PR TITLE
(Angrylion) Init AL's config struct when InitiateGFX is called

### DIFF
--- a/mupen64plus-video-angrylion/interface.cpp
+++ b/mupen64plus-video-angrylion/interface.cpp
@@ -332,6 +332,7 @@ void angrylionSetRenderingCallback(void (*callback)(int))
 
 int angrylionInitiateGFX (GFX_INFO Gfx_Info)
 {
+   n64video_config_init(&config);
    return 0;
 }
 


### PR DESCRIPTION
This change will re-enable the utilization of the parallel angrylion system, because it sets `config.parallel` to true. It would stay set to false otherwise.

A better fix would be to perhaps check the "multithreaded" core option and re-initialize the video plugin after changing `config.parallel` accordingly.