### PR TITLE
Added -DARM_FIX for rpi and odroid CPUFLAGS - fixes #544

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,7 @@ ifneq (,$(findstring unix,$(platform)))
       else
          CPUFLAGS += -DARMv5_ONLY -DNO_ASM
       endif
+      CPUFLAGS += -DARM_FIX
    endif
 
    # ODROIDs
@@ -162,7 +163,7 @@ ifneq (,$(findstring unix,$(platform)))
       BOARD := $(shell cat /proc/cpuinfo | grep -i odroid | awk '{print $$3}')
       GLES = 1
       GL_LIB := -lGLESv2
-      CPUFLAGS += -DNO_ASM -DARM -D__arm__ -DARM_ASM -D__NEON_OPT -DNOSSE
+      CPUFLAGS += -DNO_ASM -DARM -D__arm__ -DARM_ASM -D__NEON_OPT -DNOSSE -DARM_FIX
       CPUFLAGS += -marm -mfloat-abi=hard
       HAVE_NEON = 1
       WITH_DYNAREC=arm


### PR DESCRIPTION
This was previously included for the RPI but removed in

58e522e57239b8848ef3ee854099030b9d24e9a9

with 

```
    Removed ARM_FIX for Rpi
    
    Turns out Rpi platform is pretty f**ed and those functions are declared in the RPI includes. Leaving it out for now and just using it for the standard A7A7
```

I have no idea what this means - but it's a useless description and certainly init_assembler is not declared elsewhere as I can see ?

But I will verify this - from my testing so far this is need for any arm 32bit platform with the arm dynarec enabled. 