### PR TITLE
Fix Seg Fault on Game Unload

### DIFF
--- a/mupen64plus-core/src/r4300/r4300.c
+++ b/mupen64plus-core/src/r4300/r4300.c
@@ -144,27 +144,21 @@ void r4300_execute(void)
     {
 #if NEW_DYNAREC
         new_dyna_start();
-        if (stop)
-            new_dynarec_cleanup();
+        new_dynarec_cleanup();
 #else
         dyna_start(dynarec_setup_code);
-        if (stop)
-            PC++;
+        PC++;
 #endif
-        if (stop)
-            free_blocks();
+        free_blocks();
     }
 #endif
     else /* if (r4300emu == CORE_INTERPRETER) */
     {
         r4300_step();
-
-        if (stop)
-            free_blocks();
+        free_blocks();
     }
 
-    if (stop)
-        DebugMessage(M64MSG_INFO, "R4300 emulator finished.");
+    DebugMessage(M64MSG_INFO, "R4300 emulator finished.");
 }
 
 int retro_stop_stepping(void);


### PR DESCRIPTION
When commit https://github.com/libretro/parallel-n64/commit/11c1ae337bdbb8929761bb61b812f61ae6b47303 split r4300_execute into r4300_execute and r4300_init, it continued to check the "stop" variable, but this is undefined. Removing these checks resolves the seg fault and does not affect functionality.

Should address:
https://github.com/libretro/parallel-n64/issues/636
https://github.com/libretro/parallel-n64/issues/592
https://github.com/libretro/parallel-n64/issues/580
https://github.com/libretro/parallel-n64/issues/571

And possibly others.