### PR TITLE
Use same types as mesa and new headers shipped with gpu blobs.

### DIFF
--- a/libretro-common/include/glsm/glsm.h
+++ b/libretro-common/include/glsm/glsm.h
@@ -32,8 +32,8 @@
 RETRO_BEGIN_DECLS
 
 #ifdef HAVE_OPENGLES2
-typedef GLfloat GLdouble;
-typedef GLclampf GLclampd;
+typedef double GLdouble;
+typedef double GLclampd;
 #endif
 
 #if defined(HAVE_OPENGLES2)


### PR DESCRIPTION
Avoid typedef conflicts with some SBCs.