### PR TITLE
Fix spurious RSP crashes.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -483,7 +483,8 @@ ifneq ($(DEBUG_JIT),)
 else
 	INCFLAGS += -I$(RSPDIR_PARALLEL)/arch/simd/rsp
 	SOURCES_CXX += $(RSPDIR_PARALLEL)/rsp_jit.cpp \
-						$(RSPDIR_PARALLEL)/arch/simd/rsp/rsp_core.cpp
+				   $(RSPDIR_PARALLEL)/jit_allocator.cpp \
+				   $(RSPDIR_PARALLEL)/arch/simd/rsp/rsp_core.cpp
 	SOURCES_C += \
 				 $(RSPDIR_PARALLEL)/lightning/lib/jit_disasm.c \
 				 $(RSPDIR_PARALLEL)/lightning/lib/jit_memory.c \

--- a/mupen64plus-rsp-paraLLEl/jit_allocator.cpp
+++ b/mupen64plus-rsp-paraLLEl/jit_allocator.cpp
@@ -1,0 +1,109 @@
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#else
+#include <sys/mman.h>
+#endif
+#include <limits>
+#include <algorithm>
+
+#include "jit_allocator.hpp"
+
+namespace RSP
+{
+namespace JIT
+{
+static constexpr bool huge_va = std::numeric_limits<size_t>::max() > 0x100000000ull;
+// On 64-bit systems, we will never allocate more than one block, this is important since we must ensure that
+// relative jumps are reachable in 32-bits.
+// We won't actually allocate 1 GB on 64-bit, but just reserve VA space for it, which we have basically an infinite amount of.
+static constexpr size_t block_size = huge_va ? (1024 * 1024 * 1024) : (2 * 1024 * 1024);
+Allocator::~Allocator()
+{
+#ifdef _WIN32
+	for (auto &block : blocks)
+		VirtualFree(block.code, 0, MEM_RELEASE);
+#else
+	for (auto &block : blocks)
+		munmap(block.code, block.size);
+#endif
+}
+
+static size_t align_page(size_t offset)
+{
+	return (offset + 4095) & ~size_t(4095);
+}
+
+static bool commit_read_write(void *ptr, size_t size)
+{
+#ifdef _WIN32
+	return VirtualAlloc(ptr, size, MEM_COMMIT, PAGE_READWRITE) == ptr;
+#else
+	return mprotect(ptr, size, PROT_READ | PROT_WRITE) == 0;
+#endif
+}
+
+static bool commit_execute(void *ptr, size_t size)
+{
+#ifdef _WIN32
+	DWORD old_protect;
+	return VirtualProtect(ptr, align_page(size), PAGE_EXECUTE, &old_protect) != 0;
+#else
+	return mprotect(ptr, size, PROT_EXEC) == 0;
+#endif
+}
+
+bool Allocator::commit_code(void *code, size_t size)
+{
+	return commit_execute(code, size);
+}
+
+void *Allocator::allocate_code(size_t size)
+{
+	size = align_page(size);
+	if (blocks.empty())
+		blocks.push_back(reserve_block(std::max(size, block_size)));
+
+	auto *block = &blocks.back();
+	if (!block->code)
+		return nullptr;
+
+	block->offset = align_page(block->offset);
+	if (block->offset + size > block->size)
+		block = nullptr;
+
+	if (!block)
+	{
+		if (huge_va)
+			abort();
+		blocks.push_back(reserve_block(std::max(size, block_size)));
+		block = &blocks.back();
+	}
+
+	if (!block || !block->code)
+		return nullptr;
+
+	void *ret = block->code + block->offset;
+	block->offset += size;
+
+	if (!commit_read_write(ret, size))
+		return nullptr;
+	return ret;
+}
+
+Allocator::Block Allocator::reserve_block(size_t size)
+{
+	Block block;
+#ifdef _WIN32
+	block.code = static_cast<uint8_t *>(VirtualAlloc(nullptr, size, MEM_RESERVE, PAGE_READWRITE));
+	block.size = size;
+	return block;
+#else
+	block.code = static_cast<uint8_t *>(mmap(nullptr, size, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE,
+	                                         -1, 0));
+	block.size = size;
+	return block;
+#endif
+}
+}
+}

--- a/mupen64plus-rsp-paraLLEl/jit_allocator.hpp
+++ b/mupen64plus-rsp-paraLLEl/jit_allocator.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <vector>
+#include <stdint.h>
+
+namespace RSP
+{
+namespace JIT
+{
+class Allocator
+{
+public:
+	Allocator() = default;
+	~Allocator();
+	void operator=(const Allocator &) = delete;
+	Allocator(const Allocator &) = delete;
+
+	void *allocate_code(size_t size);
+	static bool commit_code(void *code, size_t size);
+
+private:
+	struct Block
+	{
+		uint8_t *code = nullptr;
+		size_t size = 0;
+		size_t offset = 0;
+	};
+	std::vector<Block> blocks;
+
+	static Block reserve_block(size_t size);
+};
+}
+}

--- a/mupen64plus-rsp-paraLLEl/rsp_jit.hpp
+++ b/mupen64plus-rsp-paraLLEl/rsp_jit.hpp
@@ -10,6 +10,7 @@
 
 #include "rsp_op.hpp"
 #include "state.hpp"
+#include "jit_allocator.hpp"
 
 extern "C"
 {
@@ -135,8 +136,6 @@ private:
 
 	int enter(uint32_t pc);
 
-	std::vector<jit_state_t *> cleanup_jit_states;
-
 	void init_jit_thunks();
 
 	struct
@@ -198,6 +197,7 @@ private:
 	std::vector<Link> local_branches;
 
 	RegisterCache regs;
+	Allocator allocator;
 };
 } // namespace JIT
 } // namespace RSP


### PR DESCRIPTION
We need to have our own VA allocator, since jit_jmpi is implemented as a
32-bit relative jump on x64. Ensure we only have one huge VA
reservation. For 32-bit, this is not a problem, so don't allocate huge
pages.