### PR TITLE
Fix for segfault and saving issues

### DIFF
--- a/mupen64plus-core/src/r4300/r4300.c
+++ b/mupen64plus-core/src/r4300/r4300.c
@@ -144,21 +144,27 @@ void r4300_execute(void)
     {
 #if NEW_DYNAREC
         new_dyna_start();
-        new_dynarec_cleanup();
+        if (stop)
+            new_dynarec_cleanup();
 #else
         dyna_start(dynarec_setup_code);
-        PC++;
+        if (stop)
+            PC++;
 #endif
-        free_blocks();
+        if (stop)
+            free_blocks();
     }
 #endif
     else /* if (r4300emu == CORE_INTERPRETER) */
     {
         r4300_step();
-        free_blocks();
+
+        if (stop)
+            free_blocks();
     }
 
-    DebugMessage(M64MSG_INFO, "R4300 emulator finished.");
+    if (stop)
+        DebugMessage(M64MSG_INFO, "R4300 emulator finished.");
 }
 
 int retro_stop_stepping(void);

--- a/mupen64plus-core/src/r4300/r4300.c
+++ b/mupen64plus-core/src/r4300/r4300.c
@@ -50,8 +50,8 @@
 unsigned int r4300emu = 0;
 unsigned int count_per_op = COUNT_PER_OP_DEFAULT;
 unsigned int llbit;
-#if NEW_DYNAREC < NEW_DYNAREC_ARM
 int stop;
+#if NEW_DYNAREC < NEW_DYNAREC_ARM
 int64_t reg[32], hi, lo;
 uint32_t next_interrupt;
 struct precomp_instr *PC;


### PR DESCRIPTION
Hello,

on my Android device I stumbled over #688 (and the corresponding ones: #571, #580, #592, #636, #684). Like @thekiefs said there the issue was not fixed entirely by PR #637.

So I had a look into it and at least for me I found an easy fix. Thanks @mrfixit2001 for pointing me in the right direction.

Basically it is the `stop` variable that is used in some methods of the file `mupen64plus-core/src/r4300/r4300.c`. Like @mrfixit2001 said, on ARM devices this variable is used, but it's not defined, because of lines
```c++
#if NEW_DYNAREC < NEW_DYNAREC_ARM
int stop;
int64_t reg[32], hi, lo;
[...]
#endif
```

When compiling for ARM devices the variable `stop` gets never defined, because the condition above will then be `#if 3 < 3` (for 32bit ARM) or `#if 4 < 3` (for 64bit arm), which is never true. So my "fix" is basically to detach the variable out of this if clause.

Hope this also helps others.

--------

If someone wants to try if this fix works for her/his case, then you can use these binaries (32 and 64bit): [android.zip](https://github.com/libretro/parallel-n64/files/5664000/android.zip)
These are compiled on the latest master (29e7f39) with my fix.