### PR TITLE
hide GL core options with HAVE_OPENGL=0 and apply it to OSX and iOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,8 @@ else ifneq (,$(findstring osx,$(platform)))
 	CFLAGS += -DDONT_WANT_ARM_OPTIMIZATIONS
 	HAVE_OPENGL=0
    else
-        GL_LIB := -framework OpenGL
+   # OpenGL is broken on non-ARM now, too
+   HAVE_OPENGL=0
    endif
 
    # Target Dynarec
@@ -342,7 +343,7 @@ else ifneq (,$(findstring ios,$(platform)))
 
    TARGET := $(TARGET_NAME)_libretro_ios.dylib
    DEFINES += -DIOS
-   GLES = 1
+   HAVE_OPENGL=0
    WITH_DYNAREC=
    PLATFORM_EXT := unix
    MINVERSION :=
@@ -354,12 +355,10 @@ else ifneq (,$(findstring ios,$(platform)))
    LDFLAGS += -dynamiclib
 
    fpic = -fPIC
-   GL_LIB := -framework OpenGLES
    ifeq ($(platform),ios-arm64)
       CC = clang -arch arm64 -isysroot $(IOSSDK)
       CXX = clang++ -arch arm64 -isysroot $(IOSSDK)
       CFLAGS += -DDONT_WANT_ARM_OPTIMIZATIONS
-      FORCE_GLES=1
       CXXFLAGS += -Wc++11-extensions -std=c++11 -stdlib=libc++ -Wc++11-long-long
       CPUFLAGS += -marm -mfpu=neon -mfloat-abi=softfp
       HAVE_NEON=0
@@ -384,7 +383,6 @@ else ifeq ($(platform), tvos-arm64)
 
    TARGET := $(TARGET_NAME)_libretro_tvos.dylib
    DEFINES += -DIOS
-   GLES = 1
    WITH_DYNAREC=
    PLATFORM_EXT := unix
    MINVERSION :=
@@ -396,7 +394,7 @@ else ifeq ($(platform), tvos-arm64)
    LDFLAGS += -dynamiclib
 
    fpic = -fPIC
-   GL_LIB := -framework OpenGLES
+   HAVE_OPENGL=0
       CC = cc -arch arm64 -isysroot $(IOSSDK)
       CXX = c++ -arch arm64 -isysroot $(IOSSDK)
       CFLAGS += -DDONT_WANT_ARM_OPTIMIZATIONS
@@ -419,7 +417,7 @@ else ifneq (,$(findstring theos_ios,$(platform)))
 
    LIBRARY_NAME = $(TARGET_NAME)_libretro_ios
    DEFINES += -DIOS
-   GLES = 1
+   HAVE_OPENGL=0
    WITH_DYNAREC=arm
 
    PLATCFLAGS += -DHAVE_POSIX_MEMALIGN -DNO_ASM

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -281,8 +281,10 @@ static void core_settings_set_defaults(void)
    {
       if (rsp_var.value && !strcmp(rsp_var.value, "auto"))
          core_settings_autoselect_rsp_plugin();
+#ifdef HAVE_OPENGL
       if (rsp_var.value && !strcmp(rsp_var.value, "hle") && !vulkan_inited)
          rsp_plugin = RSP_HLE;
+#endif
       if (rsp_var.value && !strcmp(rsp_var.value, "cxd4"))
          rsp_plugin = RSP_CXD4;
       if (rsp_var.value && !strcmp(rsp_var.value, "parallel"))
@@ -404,7 +406,11 @@ static void setup_variables(void)
 #endif
       },
       { "parallel-n64-rspplugin",
-         "RSP Plugin; auto|hle|cxd4"
+         "RSP Plugin; auto"
+#ifdef HAVE_OPENGL
+		 "|hle"
+#endif
+		 "|cxd4"
 #ifdef HAVE_PARALLEL_RSP
          "|parallel"
 #endif

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -235,6 +235,7 @@ static void core_settings_set_defaults(void)
    {
       if (gfx_var.value && !strcmp(gfx_var.value, "auto"))
          core_settings_autoselect_gfx_plugin();
+#ifdef HAVE_OPENGL
 #if defined(HAVE_GLN64) || defined(HAVE_GLIDEN64)
       if (gfx_var.value && !strcmp(gfx_var.value, "gln64") && gl_inited)
          gfx_plugin = GFX_GLN64;
@@ -247,6 +248,7 @@ static void core_settings_set_defaults(void)
 #ifdef HAVE_GLIDE64
       if(gfx_var.value && !strcmp(gfx_var.value, "glide64") && gl_inited)
          gfx_plugin = GFX_GLIDE64;
+#endif
 #endif
 #ifdef HAVE_THR_AL
 	  if(gfx_var.value && !strcmp(gfx_var.value, "angrylion"))
@@ -392,8 +394,12 @@ static void setup_variables(void)
       { "parallel-n64-send_allist_to_hle_rsp",
          "Send audio lists to HLE RSP; disabled|enabled" },
       { "parallel-n64-gfxplugin",
-         "GFX Plugin; auto|glide64|gln64|rice|angrylion"
-#if defined(HAVE_PARALLEL)
+         "GFX Plugin; auto"
+#ifdef HAVE_OPENGL
+         "|glide64|gln64|rice"
+#endif         
+         "|angrylion"
+#ifdef HAVE_PARALLEL
             "|parallel"
 #endif
       },
@@ -403,6 +409,7 @@ static void setup_variables(void)
          "|parallel"
 #endif
          },
+#if defined(HAVE_OPENGL)||defined(HAVE_PARALLEL)
       { "parallel-n64-screensize",
 #ifdef CLASSIC
          "Resolution (restart); 320x240|640x480|960x720|1280x960|1440x1080|1600x1200|1920x1440|2240x1680|2880x2160|5760x4320" },
@@ -421,6 +428,7 @@ static void setup_variables(void)
       { "parallel-n64-polyoffset-units",
        "(Glide64) Polygon Offset Units; -3.0|-2.5|-2.0|-1.5|-1.0|-0.5|0.0|0.5|1.0|1.5|2.0|2.5|3.0|3.5|4.0|4.5|5.0|-3.5|-4.0|-4.5|-5.0"
       },
+#endif
       { "parallel-n64-angrylion-vioverlay",
        "(Angrylion) VI Overlay; Filtered|AA+Blur|AA+Dedither|AA only|Unfiltered|Depth|Coverage"
       },
@@ -442,7 +450,7 @@ static void setup_variables(void)
       { "parallel-n64-alt-map",
         "Independent C-button Controls; disabled|enabled" },
 
-#ifndef HAVE_PARALLEL
+#if defined(HAVE_PARALLEL)||!defined(HAVE_OPENGL)
       { "parallel-n64-vcache-vbo",
          "(Glide64) Vertex cache VBO (restart); disabled|enabled" },
 #endif


### PR DESCRIPTION
OSX and iOS both break with any OpenGL options but are fast enough to deal with LLE software rendering. Unfortunately, they insta-crash on load unless users manually set the plugins to Angrylion and cxd4/ParaLLEl-RSP via text editor, which is a pretty big ask (they have to know the exact syntax, etc.).

This PR forces those plugins and removes OpenGL entirely from those builds, while also doing a better job of hiding GL-dependent core options.