### PR TITLE
Makefile fix to enable build for "unix-armv7-hardfloat-neon"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,7 @@ ifneq (,$(findstring unix,$(platform)))
    #######################################
    # Generic ARM
    ifneq (,$(findstring armv,$(platform)))
-      CPUFLAGS += -DNO_ASM -DARM -D__arm__ -DARM_ASM -DNOSSE
+      CPUFLAGS += -DNO_ASM -DARM -D__arm__ -DARM_ASM -DNOSSE -DARM_FIX
       WITH_DYNAREC=arm
       ifneq (,$(findstring neon,$(platform)))
          CPUFLAGS += -D__NEON_OPT -mfpu=neon


### PR DESCRIPTION
"armv" platform is recognized by the makefile, but actual compilation was not successful for "unix-armv7-hardfloat-neon" (one of the options in libretro-super build scripts).
Added -DARM_FIX from other similar platforms.