### PR TITLE
Fix emscripten build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -473,7 +473,8 @@ else ifeq ($(platform), emscripten)
    WITH_DYNAREC :=
 
    HAVE_PARALLEL = 0
-   CPUFLAGS += -DNOSSE -DEMSCRIPTEN -DNO_ASM -DNO_LIBCO -s USE_ZLIB=1 -s PRECISE_F32=1
+   HAVE_THR_AL = 1
+   CPUFLAGS += -DNOSSE -DEMSCRIPTEN -DNO_ASM -DNO_LIBCO
 
    WITH_DYNAREC =
    CC = emcc
@@ -899,6 +900,8 @@ ifeq ($(DEBUG), 1)
    endif
 else
 ifneq (,$(findstring msvc,$(platform)))
+   CPUOPTS += -O2
+else ifeq ($(platform), emscripten)
    CPUOPTS += -O2
 else
 	CPUOPTS += -Ofast

--- a/mupen64plus-core/src/si/pif.c
+++ b/mupen64plus-core/src/si/pif.c
@@ -81,7 +81,7 @@ void init_pif(struct pif *pif,
 
    for (i = 0; i < GAME_CONTROLLERS_COUNT; ++i)
    {
-      static  channels[] = { 0, 1, 2, 3 };
+      static int32_t channels[] = { 0, 1, 2, 3 };
       init_game_controller(
             &pif->controllers[i], 
             (void*)&channels[i],


### PR DESCRIPTION
* `-s USE_ZLIB=1` and `-s PRECISE_F32=1` are either not required or legacy.
* `HAVE_THR_AL=1` guarantees a software renderer as a fallback for OpenGL.
* And a minor fix to prevent an implicit integer declaration, also for portability.