### PR TITLE
Allow build with gcc-13

### DIFF
--- a/mupen64plus-video-angrylion/parallel_al.cpp
+++ b/mupen64plus-video-angrylion/parallel_al.cpp
@@ -10,6 +10,7 @@
 #include <mutex>
 #include <thread>
 #include <vector>
+#include <stdexcept>
 
 class Parallel
 {


### PR DESCRIPTION
Haiku now ships with gcc-13 by default, and it looks like this header, which was included implicitly with older GCC versions, is now required.