### PR TITLE
[Security] Fixed multiple buffer overflow vulnerabilities leading to arbitrary code execution

### DIFF
--- a/mupen64plus-core/src/ri/rdram.c
+++ b/mupen64plus-core/src/ri/rdram.c
@@ -23,6 +23,7 @@
 #include "ri_controller.h"
 
 #include "../memory/memory.h"
+#include "./safe_rdram.h"
 
 #include <string.h>
 
@@ -65,19 +66,13 @@ int write_rdram_regs(void* opaque, uint32_t address, uint32_t value, uint32_t ma
 int read_rdram_dram(void* opaque, uint32_t address, uint32_t* value)
 {
     struct ri_controller* ri = (struct ri_controller*)opaque;
-    uint32_t addr            = RDRAM_DRAM_ADDR(address);
-
-    *value = ri->rdram.dram[addr];
-
+    *value = rdram_safe_read_word(ri->rdram.dram, address);
     return 0;
 }
 
 int write_rdram_dram(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 {
     struct ri_controller* ri = (struct ri_controller*)opaque;
-    uint32_t addr            = RDRAM_DRAM_ADDR(address);
-
-    ri->rdram.dram[addr] = MASKED_WRITE(&ri->rdram.dram[addr], value, mask);
-
+    rdram_safe_masked_write_word(ri->rdram.dram, address, value, mask);
     return 0;
 }

--- a/mupen64plus-core/src/ri/rdram.h
+++ b/mupen64plus-core/src/ri/rdram.h
@@ -29,10 +29,6 @@
 #define RDRAM_REG(a)    ((a & 0x3ff) >> 2)
 #endif
 
-#ifndef RDRAM_DRAM_ADDR
-#define RDRAM_DRAM_ADDR(a) ((address & 0xffffff) >> 2)
-#endif
-
 enum rdram_registers
 {
     RDRAM_CONFIG_REG,

--- a/mupen64plus-core/src/ri/safe_rdram.h
+++ b/mupen64plus-core/src/ri/safe_rdram.h
@@ -1,0 +1,40 @@
+#ifndef M64P_RI_SAFE_RDRAM_H
+#define M64P_RI_SAFE_RDRAM_H
+
+#include <stdint.h>
+
+inline uint8_t rdram_safe_read_byte(const void *rdram, uint32_t addr)
+{
+    addr &= 0x3ffffffu;
+    return (addr < 0x800000u) ? ((const uint8_t*)rdram)[addr] : 0;
+}
+
+inline void rdram_safe_write_byte(void *rdram, uint32_t addr, uint8_t value)
+{
+    addr &= 0x3ffffffu;
+    if (addr < 0x800000u)
+        ((uint8_t*)rdram)[addr] = value;
+}
+
+inline uint32_t rdram_safe_read_word(const void *rdram, uint32_t addr)
+{
+    addr = (addr & 0x3ffffffu) >> 2;
+    return (addr < 0x200000u) ? ((const uint32_t*)rdram)[addr] : 0u;
+}
+
+inline void rdram_safe_write_word(void *rdram, uint32_t addr, uint32_t value)
+{
+    addr = (addr & 0x3ffffffu) >> 2;
+    if (addr < 0x200000u)
+        ((uint32_t*)rdram)[addr] = value;
+}
+
+inline void rdram_safe_masked_write_word(void *rdram, uint32_t addr, uint32_t value, uint32_t mask)
+{
+    addr = (addr & 0x3ffffffu) >> 2;
+    if (addr >= 0x200000u) return;
+    uint32_t *word = &((uint32_t*)rdram)[addr];
+    *word = (*word & ~mask) | (value & mask);
+}
+
+#endif

--- a/mupen64plus-core/src/rsp/rsp_core.c
+++ b/mupen64plus-core/src/rsp/rsp_core.c
@@ -29,6 +29,7 @@
 #include "r4300/r4300_core.h"
 #include "../rdp/rdp_core.h"
 #include "../ri/ri_controller.h"
+#include "../ri/safe_rdram.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -46,7 +47,7 @@ static void dma_sp_write(struct rsp_core* sp, unsigned length, unsigned count, u
     {
         for(i = 0; i < length; i++)
         {
-            spmem[memaddr^S8] = dram[dramaddr^S8];
+            spmem[(memaddr^S8) & 0xfffu] = rdram_safe_read_byte(dram, dramaddr^S8);
             memaddr++;
             dramaddr++;
         }
@@ -67,7 +68,7 @@ static void dma_sp_read(struct rsp_core* sp, unsigned length, unsigned count, un
     {
         for(i = 0; i < length; i++)
         {
-            dram[dramaddr^S8] = spmem[memaddr^S8];
+            rdram_safe_write_byte(dram, dramaddr^S8, spmem[(memaddr^S8) & 0xfffu]);
             memaddr++;
             dramaddr++;
         }


### PR DESCRIPTION
Backporting security fixes from the Parallel Launcher core to the upstream ParallelN64 core.

This patch fixes multiple vulnerabilities in which bounds checking on DMA operations is either implemented incorrectly or is missing entirely, allowing a malicious romhack or homebrew rom to write arbitrary data outside of the emulated RAM buffers, ultimately leading to full arbitrary code execution on the host machine.