### PR TITLE
Add angle snapping to better support circular analog sticks

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -104,6 +104,8 @@ static bool vulkan_inited           = false;
 static bool gl_inited               = false;
 
 int astick_deadzone                 = 0;
+int astick_snap_active              = 0;
+int astick_snap_max_angle           = 15;
 int astick_sensitivity              = 100;
 int first_time                      = 1;
 bool flip_only                      = false;
@@ -349,6 +351,10 @@ static void setup_variables(void)
         "Analog Deadzone (percent); 15|20|25|30|0|5|10"},
       {"parallel-n64-astick-sensitivity",
         "Analog Sensitivity (percent); 100|105|110|115|120|125|130|135|140|145|150|200|50|55|60|65|70|75|80|85|90|95"},
+      { "parallel-n64-snap-angle-active",
+      "Snap Controller Angle; disabled|enabled" },
+      { "parallel-n64-snap-max-angle",
+         "Maximum Snap Angle (value of 5 would mean 85 to 95 degrees are snapped to 90); 1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21" },
       {"parallel-n64-pak1",
 #ifdef CLASSIC
         "Player 1 Pak; memory|rumble|none"},
@@ -1492,6 +1498,25 @@ void update_variables(bool startup)
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
       astick_deadzone = (int)(atoi(var.value) * 0.01f * 0x8000);
+
+   var.key = "parallel-n64-snap-angle-active";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "enabled"))
+         astick_snap_active = 1;
+      else if (!strcmp(var.value, "disabled"))
+         astick_snap_active = 0;
+   }
+
+   var.key = "parallel-n64-snap-angle";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      astick_snap_max_angle = (int)(atoi(var.value));
+   }
 
    var.key = "parallel-n64-astick-sensitivity";
    var.value = NULL;

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -103,12 +103,13 @@ float polygonOffsetUnits            = 0.0f;
 static bool vulkan_inited           = false;
 static bool gl_inited               = false;
 
-int astick_deadzone                 = 0;
-int astick_snap_active              = 0;
-int astick_snap_max_angle           = 15;
-int astick_sensitivity              = 100;
-int first_time                      = 1;
-bool flip_only                      = false;
+int astick_deadzone                       = 0;
+int astick_snap_active                    = 0;
+int astick_snap_max_angle                 = 15;
+int astick_snap_min_displacement_percent  = 70;
+int astick_sensitivity                    = 100;
+int first_time                            = 1;
+bool flip_only                            = false;
 
 static uint8_t* cart_data           = NULL;
 static uint32_t cart_size           = 0;
@@ -351,10 +352,12 @@ static void setup_variables(void)
         "Analog Deadzone (percent); 15|20|25|30|0|5|10"},
       {"parallel-n64-astick-sensitivity",
         "Analog Sensitivity (percent); 100|105|110|115|120|125|130|135|140|145|150|200|50|55|60|65|70|75|80|85|90|95"},
-      { "parallel-n64-snap-angle-active",
+      { "parallel-n64-astick-snap-angle-active",
       "Snap Controller Angle; disabled|enabled" },
-      { "parallel-n64-snap-max-angle",
+      { "parallel-n64-astick-snap-max-angle",
          "Maximum Snap Angle (value of 5 would mean 85 to 95 degrees are snapped to 90); 1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21" },
+      { "parallel-n64-astick-snap-min-displacement-percent",
+         "Which percentage of displacement of the stick from the center causes snap to activate (zero means always); 0|10|20|30|40|50|60|65|70|75|80|85|90|95" },
       {"parallel-n64-pak1",
 #ifdef CLASSIC
         "Player 1 Pak; memory|rumble|none"},
@@ -1499,7 +1502,7 @@ void update_variables(bool startup)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
       astick_deadzone = (int)(atoi(var.value) * 0.01f * 0x8000);
 
-   var.key = "parallel-n64-snap-angle-active";
+   var.key = "parallel-n64-astick-snap-angle-active";
    var.value = NULL;
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
@@ -1510,12 +1513,20 @@ void update_variables(bool startup)
          astick_snap_active = 0;
    }
 
-   var.key = "parallel-n64-snap-angle";
+   var.key = "parallel-n64-astick-snap-angle";
    var.value = NULL;
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       astick_snap_max_angle = (int)(atoi(var.value));
+   }
+
+   var.key = "parallel-n64-astick-snap-min-displacement-percent";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      astick_snap_min_displacement_percent = (int)(atoi(var.value));
    }
 
    var.key = "parallel-n64-astick-sensitivity";


### PR DESCRIPTION
This change is the result of [this discussion](https://github.com/libretro/parallel-n64/issues/792).
I will also add the text at the bottom.
The goal of this change is to make circular design analog sticks (like on the XBox-Controller) behave much more closely to the notched controllers that were originally used on the N64 or the GameCube.

These commits introduce three new settings:
- astick-snap-active
- astick-snap-max-angle
- astick-snap-min-displacement-percent

These are used as follows:
**astick-snap-active**: Enable / Disable analog stick angle snapping

**astick-snap-max-angle**: The maximum angle offset that will snap to the nearest cardinal direction. Example: A setting of 5 will snap 85 to 95 to 90. A setting of 10 will snap 80 to 100 to 90.

**astick-snap-min-displacement-percent**: The classic, notched controllers will only guide you to a cardinal direction when the stick displacement from the center is close to a maximum. This allows full freedom on slower movement. This setting, if for example set to 80% will only snap to the next cardinal direction as soon as the stick is at least 80% to its' maximum displacement from the center.

Thank you for your consideration.
Halest

-----------------
Here's what was originally said:
Many emulators have a setting to snap the control stick to cardinal directions to simulate a notched control stick like on the N64 or GameCube controller.
Usually this includes a setting, which offsets to snap to the nearest cardinal direction.
For example the setting is set to "5", angles from 85 to 95 would snap to 90.

Why
- Closer emulation of classic controller behaviour
- Speedrunning and such
- Better support for circular controllers