### PR TITLE
Backport security fixes to upstream ParallelN64

### DIFF
--- a/mupen64plus-core/src/ai/ai_controller.c
+++ b/mupen64plus-core/src/ai/ai_controller.c
@@ -189,7 +189,7 @@ int read_ai_regs(void* opaque, uint32_t address, uint32_t* value)
 		  ai->last_read = *value;
     }
     else
-        *value = ai->regs[reg];
+        *value = (reg < AI_REGS_COUNT) ? ai->regs[reg] : 0u;
 
     return 0;
 }
@@ -230,7 +230,8 @@ int write_ai_regs(void* opaque, uint32_t address,
          return 0;
    }
 
-   ai->regs[reg] = MASKED_WRITE(&ai->regs[reg], value, mask);
+   if (reg < AI_REGS_COUNT)
+       ai->regs[reg] = MASKED_WRITE(&ai->regs[reg], value, mask);
 
    return 0;
 }

--- a/mupen64plus-core/src/pi/pi_controller.c
+++ b/mupen64plus-core/src/pi/pi_controller.c
@@ -344,7 +344,7 @@ int read_pi_regs(void* opaque, uint32_t address, uint32_t* value)
     struct pi_controller* pi = (struct pi_controller*)opaque;
     uint32_t reg             = PI_REG(address);
 
-    *value                   = pi->regs[reg];
+    *value                   = (reg < PI_REGS_COUNT) ? pi->regs[reg] : 0u;
 
     return 0;
 }
@@ -399,7 +399,8 @@ int write_pi_regs(void* opaque, uint32_t address,
          return 0;
    }
 
-   pi->regs[reg] = MASKED_WRITE(&pi->regs[reg], value, mask);
+   if (reg < PI_REGS_COUNT)
+       pi->regs[reg] = MASKED_WRITE(&pi->regs[reg], value, mask);
 
    return 0;
 }

--- a/mupen64plus-core/src/r4300/mi_controller.c
+++ b/mupen64plus-core/src/r4300/mi_controller.c
@@ -78,7 +78,7 @@ int read_mi_regs(void* opaque, uint32_t address, uint32_t* value)
     struct r4300_core* r4300 = (struct r4300_core*)opaque;
     uint32_t reg = mi_reg(address);
 
-    *value = r4300->mi.regs[reg];
+    *value = (reg < MI_REGS_COUNT) ? r4300->mi.regs[reg] : 0u;
 
     return 0;
 }

--- a/mupen64plus-core/src/rdp/rdp_core.c
+++ b/mupen64plus-core/src/rdp/rdp_core.c
@@ -80,7 +80,7 @@ int read_dpc_regs(void* opaque, uint32_t address, uint32_t* value)
     struct rdp_core* dp = (struct rdp_core*)opaque;
     uint32_t reg        = DPC_REG(address);
 
-    *value              = dp->dpc_regs[reg];
+    *value              = (reg < DPC_REGS_COUNT) ? dp->dpc_regs[reg] : 0u;
 
     return 0;
 }
@@ -103,7 +103,8 @@ int write_dpc_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
          return 0;
    }
 
-   dp->dpc_regs[reg] = MASKED_WRITE(&dp->dpc_regs[reg], value, mask);
+   if (reg < DPC_REGS_COUNT)
+       dp->dpc_regs[reg] = MASKED_WRITE(&dp->dpc_regs[reg], value, mask);
 
    switch(reg)
    {
@@ -125,7 +126,7 @@ int read_dps_regs(void* opaque, uint32_t address, uint32_t* value)
     struct rdp_core* dp = (struct rdp_core*)opaque;
     uint32_t reg        = DPS_REG(address);
 
-    *value = dp->dps_regs[reg];
+    *value = (reg < DPS_REGS_COUNT) ? dp->dps_regs[reg] : 0u;
 
     return 0;
 }
@@ -135,7 +136,8 @@ int write_dps_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
     struct rdp_core* dp = (struct rdp_core*)opaque;
     uint32_t reg        = DPS_REG(address);
 
-    dp->dps_regs[reg] = MASKED_WRITE(&dp->dps_regs[reg], value, mask);
+    if (reg < DPS_REGS_COUNT)
+        dp->dps_regs[reg] = MASKED_WRITE(&dp->dps_regs[reg], value, mask);
 
     return 0;
 }

--- a/mupen64plus-core/src/ri/rdram.c
+++ b/mupen64plus-core/src/ri/rdram.c
@@ -47,7 +47,7 @@ int read_rdram_regs(void* opaque, uint32_t address, uint32_t* value)
     struct ri_controller* ri = (struct ri_controller*)opaque;
     uint32_t reg             = RDRAM_REG(address);
 
-    *value                   = ri->rdram.regs[reg];
+    *value                   = (reg < RDRAM_REGS_COUNT) ? ri->rdram.regs[reg] : 0u;
 
     return 0;
 }
@@ -57,7 +57,8 @@ int write_rdram_regs(void* opaque, uint32_t address, uint32_t value, uint32_t ma
     struct ri_controller* ri = (struct ri_controller*)opaque;
     uint32_t reg             = RDRAM_REG(address);
 
-    ri->rdram.regs[reg] = MASKED_WRITE(&ri->rdram.regs[reg], value, mask);
+    if (reg < RDRAM_REGS_COUNT)
+        ri->rdram.regs[reg] = MASKED_WRITE(&ri->rdram.regs[reg], value, mask);
 
     return 0;
 }

--- a/mupen64plus-core/src/ri/ri_controller.c
+++ b/mupen64plus-core/src/ri/ri_controller.c
@@ -52,7 +52,7 @@ int read_ri_regs(void* opaque, uint32_t address, uint32_t *word)
    struct ri_controller* ri = (struct ri_controller*)opaque;
     uint32_t reg             = RI_REG(address);
 
-    *word                   = ri->regs[reg];
+    *word                   = (reg < RI_REGS_COUNT) ? ri->regs[reg] : 0u;
 
     return 0;
 }
@@ -63,7 +63,8 @@ int write_ri_regs(void* opaque, uint32_t address, uint32_t word, uint32_t mask)
     struct ri_controller* ri = (struct ri_controller*)opaque;
     uint32_t reg             = RI_REG(address);
 
-    ri->regs[reg] = MASKED_WRITE(&ri->regs[reg], word, mask);
+    if (reg < RI_REGS_COUNT)
+        ri->regs[reg] = MASKED_WRITE(&ri->regs[reg], word, mask);
 
     return 0;
 }

--- a/mupen64plus-core/src/rsp/rsp_core.c
+++ b/mupen64plus-core/src/rsp/rsp_core.c
@@ -195,7 +195,7 @@ int read_rsp_regs(void* opaque, uint32_t address, uint32_t* value)
     struct rsp_core* sp = (struct rsp_core*)opaque;
     uint32_t reg        = RSP_REG(address);
 
-    *value = sp->regs[reg];
+    *value = (reg < SP_REGS_COUNT) ? sp->regs[reg] : 0u;
 
     if (reg == SP_SEMAPHORE_REG)
         sp->regs[SP_SEMAPHORE_REG] = 1;
@@ -218,7 +218,8 @@ int write_rsp_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
           return 0;
     }
 
-    sp->regs[reg] = MASKED_WRITE(&sp->regs[reg], value, mask);
+    if (reg < SP_REGS_COUNT)
+        sp->regs[reg] = MASKED_WRITE(&sp->regs[reg], value, mask);
 
     switch(reg)
     {
@@ -251,7 +252,7 @@ int read_rsp_regs2(void* opaque, uint32_t address, uint32_t* value)
     struct rsp_core* sp = (struct rsp_core*)opaque;
     uint32_t reg        = RSP_REG2(address);
 
-    *value = sp->regs2[reg];
+    *value = (reg < SP_REGS2_COUNT) ? sp->regs2[reg] : 0u;
 
     return 0;
 }
@@ -261,7 +262,8 @@ int write_rsp_regs2(void* opaque, uint32_t address, uint32_t value, uint32_t mas
     struct rsp_core* sp = (struct rsp_core*)opaque;
     uint32_t reg        = RSP_REG2(address);
 
-    sp->regs2[reg] = MASKED_WRITE(&sp->regs2[reg], value, mask);
+    if (reg < SP_REGS2_COUNT)
+        sp->regs2[reg] = MASKED_WRITE(&sp->regs2[reg], value, mask);
 
     return 0;
 }

--- a/mupen64plus-core/src/si/si_controller.c
+++ b/mupen64plus-core/src/si/si_controller.c
@@ -139,7 +139,7 @@ int read_si_regs(void* opaque, uint32_t address, uint32_t* value)
     struct si_controller* si = (struct si_controller*)opaque;
     uint32_t reg             = SI_REG(address);
 
-    *value                   = si->regs[reg];
+    *value                   = (reg < SI_REGS_COUNT) ? si->regs[reg] : 0u;
 
     return 0;
 }

--- a/mupen64plus-core/src/vi/vi_controller.c
+++ b/mupen64plus-core/src/vi/vi_controller.c
@@ -104,7 +104,7 @@ int read_vi_regs(void* opaque, uint32_t address, uint32_t *word)
         vi->regs[VI_CURRENT_REG] = (vi->regs[VI_CURRENT_REG] & (~1)) | vi->field;
     }
 
-    *word = vi->regs[reg];
+    *word = (reg < VI_REGS_COUNT) ? vi->regs[reg] : 0u;
 
     return 0;
 }
@@ -139,7 +139,8 @@ int write_vi_regs(void* opaque, uint32_t address,
           return 0;
     }
 
-    vi->regs[reg] = MASKED_WRITE(&vi->regs[reg], word, mask);
+    if (reg < VI_REGS_COUNT)
+        vi->regs[reg] = MASKED_WRITE(&vi->regs[reg], word, mask);
 
     return 0;
 }


### PR DESCRIPTION
Fixes a buffer overflow when attempting to read or write out of bounds memory mapped registers, which can lead to arbitrary code execution