### PR TITLE
webOS: static link libstdc++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,7 @@ ifneq (,$(findstring unix,$(platform)))
       HAVE_NEON = 1
       WITH_DYNAREC=arm
       CPUFLAGS += -mcpu=cortex-a9 -mfpu=neon
+      LDFLAGS += -static-libgcc -static-libstdc++
    endif
 
    # Classic Platforms ####################


### PR DESCRIPTION
Seems like we need to static link libstdc++ as well :+1: 