### PR TITLE
Add commit hash to core version

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1019,7 +1019,7 @@ void retro_set_environment(retro_environment_t cb)
 void retro_get_system_info(struct retro_system_info *info)
 {
    info->library_name = "ParaLLEl N64";
-   info->library_version = "1.0";
+   info->library_version = "1.0" GIT_VERSION;
    info->valid_extensions = "n64|v64|z64|bin|u1|ndd";
    info->need_fullpath = false;
    info->block_extract = false;


### PR DESCRIPTION
Just a simple change to include the commit hash in the displayed core version string, for better identification of the current build (akin to other existing libretro cores).