### PR TITLE
Fix two decisions taken from the cartridge's IPL3

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -503,6 +503,31 @@ static void core_settings_autoselect_rsp_plugin(void)
     * below upgrades that to the parallel RSP when available. */
    {
       const uint8_t* cart = (const uint8_t*)mem_base_u32(g_mem_base, MM_CART_ROM);
+      if (cart && g_rom_size >= 0x1000)
+      {
+         /* Autoselect runs from emu_step_initialize(), which is before
+          * main_run() byte-swaps the cartridge into host word order, so
+          * mem_base still holds the file's own order here.  cic_ipl3_known
+          * reads native uint32, and on a little-endian host that yields
+          * transposed words summing to a value no retail CIC matches: every
+          * cartridge looked like homebrew and went to the LLE core.  Sum a
+          * corrected copy instead of the live buffer. */
+         uint32_t ipl3[0xfc0/4];
+         memcpy(ipl3, cart + 0x40, sizeof(ipl3));
+#if !defined(MSB_FIRST)
+         if (!g_RomWordsLittleEndian)
+         {
+            size_t i;
+            for (i = 0; i < sizeof(ipl3)/sizeof(ipl3[0]); ++i)
+               ipl3[i] = ((ipl3[i] & UINT32_C(0x000000ff)) << 24)
+                       | ((ipl3[i] & UINT32_C(0x0000ff00)) <<  8)
+                       | ((ipl3[i] & UINT32_C(0x00ff0000)) >>  8)
+                       | ((ipl3[i] & UINT32_C(0xff000000)) >> 24);
+         }
+#endif
+         if (!cic_ipl3_known(ipl3))
+            rsp_plugin = RSP_CXD4;
+      }
       if (cart && g_rom_size >= 0x1000 && !cic_ipl3_known(cart + 0x40))
          rsp_plugin = RSP_CXD4;
    }

--- a/mupen64plus-core/src/device/pif/bootrom_hle.c
+++ b/mupen64plus-core/src/device/pif/bootrom_hle.c
@@ -26,6 +26,7 @@
 
 #include "api/m64p_types.h"
 #include "device/device.h"
+#include "device/pif/cic.h"
 #include "device/r4300/r4300_core.h"
 #include "device/rcp/ai/ai_controller.h"
 #include "device/rcp/pi/pi_controller.h"
@@ -33,6 +34,7 @@
 #include "device/rcp/rsp/rsp_core.h"
 #include "device/rcp/si/si_controller.h"
 #include "device/rcp/vi/vi_controller.h"
+#include "main/main.h"
 #include "main/rom.h"
 
 static unsigned int get_tv_type(void)
@@ -120,8 +122,23 @@ void pif_bootrom_hle_execute(struct r4300_core* r4300)
 
     /* IPL2 brings the RDRAM up before handing over and leaves RI_SELECT
      * set; skipping the boot rom means nothing ever did, so it reads back
-     * zero and an IPL3 that checks it runs its own init sequence instead. */
-    r4300_write_aligned_word(r4300, R4300_KSEG1 + MM_RI_REGS + 4*RI_SELECT_REG, 0x14, ~UINT32_C(0));
+     * zero and an IPL3 that checks it runs its own init sequence instead.
+     * libdragon's open IPL3 is the one that checks, and the sequence it then runs drives
+     * RDRAM registers this core does not model.
+     *
+     * Retail IPL3 does not check: it runs its sizing procedure unconditionally,
+     * and that procedure is what publishes osMemSize at 0x80000318 and hands
+     * the module count to rdram.c through s4.  Claiming the RDRAM is already up
+     * makes it skip all of that, leaving a machine that reports no memory - so
+     * only make the claim for the cartridges that need it. */
+    if (!cic_ipl3_known(mem_base_u32(r4300->mem->base, rom_base + 0x40)))
+    {
+        r4300_write_aligned_word(r4300, R4300_KSEG1 + MM_RI_REGS + 4*RI_SELECT_REG, 0x14, ~UINT32_C(0));
+
+        /* Nothing runs the sizing procedure now, so publish what it would
+         * have found. */
+        mem_base_u32(r4300->mem->base, MM_RDRAM_DRAM)[0x318/4] = (uint32_t)g_dev.rdram.dram_size;
+    }
 
     /* copy IPL3 to dmem */
     memcpy((unsigned char*)mem_base_u32(r4300->mem->base, MM_RSP_MEM + 0x40),


### PR DESCRIPTION
Found while porting to a Raspberry Pi 5 (aarch64, GLES 3.1). Both commits
concern code that identifies a cartridge by its IPL3 checksum and acts on
the answer; both were isolated by bisecting on real hardware.

**1. The autoselect reads the checksum in the wrong byte order**

`core_settings_autoselect_rsp_plugin()` runs from `emu_step_initialize()`,
before `main_run()` byte-swaps the cartridge into host word order.
`cic_ipl3_known()` reads native `uint32`, so on a little-endian host it sums
transposed words and matches no retail CIC. Every cartridge looked like
homebrew and went to the LLE core.

Resident Evil 2 (Europe) sums to `0x000000A316ADC55A` that way, against the
`0x000000D057C85244` the table holds for it.

Most games tolerate cxd4, which is why this is easy to miss. The two that
gave it away paint from RDRAM: RE2 shredded its pre-rendered backgrounds
into repeating horizontal streaks while its polygonal characters stayed
correct, and Donkey Kong 64 lost the HLE-side microcode handling it needs.
Forcing `rspplugin=hle` fixed both, which is what placed the fault.

**2. Only claim the RDRAM is up for an IPL3 that checks**

25c769d2 sets `RI_SELECT` for every cartridge so libdragon's open IPL3 boots.
Retail IPL3 never reads it: it runs its sizing procedure unconditionally, and
that procedure publishes `osMemSize` at `0x80000318` and hands the detected
module count to `rdram.c` through `s4`. Telling it the RDRAM is already up
makes it skip all of that.

South Park Rally runs 12.3M cycles, derives a memory top from a machine that
reports no memory, and takes a TLB refill on `0x7ffffffc`. It never programs
COMPARE afterwards, so COMPARE_INT stays due at count 0 and the dynarec
re-enters `gen_interrupt()` without running an instruction: one core at 100%,
no output. Donkey Kong 64 fails more quietly and detects 4 MB.

Gating on `cic_ipl3_known()` puts retail cartridges back on exactly the path
they took before 25c769d2.

**Verification**

South Park Rally boots and Donkey Kong 64 sees 8 MB again; removing either
commit reproduces its failure.

**One caveat**: the `osMemSize` write on the unknown-IPL3 branch is not
exercised here, as I have no libdragon cartridge to test with. Happy to drop
it if you would rather keep the change minimal.