### PR TITLE
Make three GLES 3 paths reachable

### DIFF
--- a/libretro-common/glsm/glsm.c
+++ b/libretro-common/glsm/glsm.c
@@ -2065,7 +2065,7 @@ void rglClearBufferfv( 	GLenum buffer,
    log_cb(RETRO_LOG_INFO, "glClearBufferfv.\n");
 #endif
    bindFBO(GL_FRAMEBUFFER);
-#if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) && defined(HAVE_OPENGLES_3)
+#if defined(HAVE_OPENGL) || (defined(HAVE_OPENGLES) && defined(HAVE_OPENGLES3))
    glClearBufferfv(buffer, drawBuffer, value);
 #endif
 }
@@ -2091,7 +2091,7 @@ const GLubyte* rglGetStringi(GLenum name, GLuint index)
 #ifdef GLSM_DEBUG
    log_cb(RETRO_LOG_INFO, "glGetString.\n");
 #endif
-#if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) && defined(HAVE_OPENGLES_3)
+#if defined(HAVE_OPENGL) || (defined(HAVE_OPENGLES) && defined(HAVE_OPENGLES3))
    return glGetStringi(name, index);
 #else
    return NULL;
@@ -2106,7 +2106,7 @@ void rglClearBufferfi( 	GLenum buffer,
 #ifdef GLSM_DEBUG
    log_cb(RETRO_LOG_INFO, "glClearBufferfi.\n");
 #endif
-#if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) && defined(HAVE_OPENGLES_3)
+#if defined(HAVE_OPENGL) || (defined(HAVE_OPENGLES) && defined(HAVE_OPENGLES3))
    glClearBufferfi(buffer, drawBuffer, depth, stencil);
 #endif
 }
@@ -2126,7 +2126,7 @@ void rglRenderbufferStorageMultisample( 	GLenum target,
 #ifdef GLSM_DEBUG
    log_cb(RETRO_LOG_INFO, "glRenderbufferStorageMultisample.\n");
 #endif
-#if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) && defined(HAVE_OPENGLES_3)
+#if defined(HAVE_OPENGL) || (defined(HAVE_OPENGLES) && defined(HAVE_OPENGLES3))
    glRenderbufferStorageMultisample(target, samples, internalformat, width, height);
 #endif
 }

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -2361,7 +2361,7 @@ void update_variables(bool startup)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (!strcmp(var.value, "Compatible"))
-         EnableN64DepthCompare = 1; // dcCompatible
+         EnableN64DepthCompare = 2; // dcCompatible
       else if (!strcmp(var.value, "True"))
          EnableN64DepthCompare = 1; // dcFast
       else

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -1670,7 +1670,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
         "True"
 #endif
     },
-#if !defined(VC) && !defined(HAVE_OPENGLES)
     {
         CORE_NAME "-gliden64-EnableN64DepthCompare",
         "N64 Depth Compare",
@@ -1685,6 +1684,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
         },
         "False"
     },
+#if !defined(VC) && !defined(HAVE_OPENGLES)
     {
         CORE_NAME "-gliden64-EnableShadersStorage",
         "Cache GPU Shaders",


### PR DESCRIPTION
Three small fixes for code that a GLES build compiles but never reaches.
Six lines changed in total. Found on a Raspberry Pi 5 (GLES 3.1).

**1. glsm's GLES 3.0 wrappers are gated on a macro nothing defines**

Four wrappers test `HAVE_OPENGLES_3`. `Makefile.common` passes
`-DHAVE_OPENGLES3`, without the underscore, and that is what the other 79
sites in the tree test. `glClearBufferfv`, `glClearBufferfi`, `glGetStringi`
and `glRenderbufferStorageMultisample` were therefore silently dead on GLES.

The colour clear is the one that shows: GLideN64 clears frame buffers through
`rglClearBufferfv`, so buffers kept whatever was in them. Rayman 2 drew its
logo over the previous frame instead of black, and South Park left the old
image behind on a resolution change.

All four are core in GLES 3.0. `HAVE_OPENGLES_3_1` and `HAVE_OPENGLES_3_2`
are deliberately left alone: they guard entry points a plain GLES 3.0 context
need not provide.

**2. N64 depth compare is read on GLES but not declared**

The read lost its guard already; the declaration kept it, so the option never
appears in the core options on GLES and the value read is always the default.
What it needs is shader image load/store, core in GLES 3.1.

**3. "Compatible" selected Fast**

`Config.h` numbers the modes `dcDisable = 0`, `dcFast = 1`,
`dcCompatible = 2`. `update_variables()` assigned 1 for both "Compatible" and
"True", so the compatible path could not be selected at all.

Defaults are unchanged throughout; only reachability and one value differ.