### PR TITLE
Three aarch64 defects in the new dynarec

### DIFF
--- a/mupen64plus-core/src/device/r4300/new_dynarec/arm64/assem_arm64.c
+++ b/mupen64plus-core/src/device/r4300/new_dynarec/arm64/assem_arm64.c
@@ -960,7 +960,7 @@ static u_int genjmp(intptr_t addr)
   if(offset<-134217728LL||offset>=134217728LL)
   {
     int n;
-    for(n=0;n<sizeof(jump_table_symbols)/4;n++)
+    for(n=0;n<(int)(sizeof(jump_table_symbols)/sizeof(jump_table_symbols[0]));n++)
     {
       if(addr==jump_table_symbols[n])
       {

--- a/mupen64plus-core/src/device/r4300/new_dynarec/new_dynarec.c
+++ b/mupen64plus-core/src/device/r4300/new_dynarec/new_dynarec.c
@@ -3944,6 +3944,43 @@ static void wb_dirtys(signed char i_regmap[],uint64_t i_is32,uint64_t i_dirty)
   }
 }
 
+/* Write back the guest registers a faulting instruction still holds in host
+ * registers, whether or not they are marked dirty.
+ *
+ * clean_registers() deliberately understates wasdirty: it clears the bit of any
+ * register that will be written again further down the block, on the grounds
+ * that the intermediate value would never be read back from the register file.
+ * That reasoning holds for every ordinary exit -- the final value is written
+ * back before the block ends -- but not when an exception is taken. There the
+ * guest's handler runs on the register file, and the block is re-entered from
+ * it afterwards, so a register living only in a host register comes back with
+ * the value it had when the block was entered.
+ *
+ * Measured on All-Star Baseball 2000: a TLB refill on the LW at 0x0015118c, on
+ * the first source word of a new page, silently lost r16 and r17 -- the source
+ * and destination pointers of the copy loop around it. Both rewound to their
+ * loop-entry values, 40 bytes back, and every texture row after that was
+ * written at the wrong offset. Only the iteration counter survived, because it
+ * happened to still be marked dirty at that instruction.
+ *
+ * An exception path runs once per exception, so writing back a few registers
+ * that were already in sync costs nothing measurable. */
+static void wb_exception_dirtys(struct regstat *i_regs)
+{
+  /* Only host registers the instruction has not reassigned: where the entry map
+   * and the current map disagree the host register has been taken over for the
+   * result or for address generation, and its contents are no longer the guest
+   * register the entry map names. Those are exactly the ones ari64 is free to
+   * reuse precisely because they are not dirty, so leave them alone. */
+  uint64_t mask=i_regs->wasdirty;
+  int hr;
+  for(hr=0;hr<HOST_REGS;hr++) {
+    if(i_regs->regmap_entry[hr]==i_regs->regmap[hr])
+      mask|=UINT64_C(1)<<hr;
+  }
+  wb_dirtys(i_regs->regmap_entry,i_regs->was32,mask);
+}
+
 // Write out dirty registers that we need to reload (pair with load_needed_regs)
 // This writes the registers not written by store_regs_bt
 static void wb_needed_dirtys(signed char i_regmap[],uint64_t i_is32,uint64_t i_dirty,int addr)
@@ -4914,7 +4951,7 @@ static void do_cop1stub(int n)
     load_all_consts(regs[i].regmap_entry,regs[i].was32,regs[i].wasdirty,regs[i].wasconst,i);
     //if(i_regs!=&regs[i]) DebugMessage(M64MSG_VERBOSE, "oops: regs[i]=%x i_regs=%x",(int)&regs[i],(int)i_regs);
   }
-  wb_dirtys(i_regs->regmap_entry,i_regs->was32,i_regs->wasdirty);
+  wb_exception_dirtys(i_regs);
 
   if(get_reg(i_regs->regmap,CCREG)<0) {
     emit_loadreg(CCREG,HOST_CCREG);
@@ -5068,7 +5105,7 @@ static void do_readstub(int n)
   emit_jeq(0);
 
   if(!ds) load_all_consts(regs[i].regmap_entry,regs[i].was32,regs[i].wasdirty,regs[i].wasconst,i);
-  wb_dirtys(i_regs->regmap_entry,i_regs->was32,i_regs->wasdirty);
+  wb_exception_dirtys(i_regs);
 
   emit_jmp((intptr_t)&do_interrupt);
   set_jump_target(jaddr,(intptr_t)out);
@@ -5191,7 +5228,7 @@ static void inline_readstub(int type, int i, u_int addr_const, char addr, struct
     emit_jeq(0);
 
     if(!ds) load_all_consts(regs[i].regmap_entry,regs[i].was32,regs[i].wasdirty,regs[i].wasconst,i);
-    wb_dirtys(i_regs->regmap_entry,i_regs->was32,i_regs->wasdirty);
+    wb_exception_dirtys(i_regs);
 
     emit_jmp((intptr_t)&do_interrupt);
     set_jump_target(jaddr,(intptr_t)out);
@@ -5304,7 +5341,7 @@ static void do_writestub(int n)
   emit_jeq(0);
 
   if(!ds) load_all_consts(regs[i].regmap_entry,regs[i].was32,regs[i].wasdirty,regs[i].wasconst,i);
-  wb_dirtys(i_regs->regmap_entry,i_regs->was32,i_regs->wasdirty);
+  wb_exception_dirtys(i_regs);
 
   emit_jmp((intptr_t)&do_interrupt);
   set_jump_target(jaddr,(intptr_t)out);
@@ -5400,7 +5437,7 @@ static void inline_writestub(int type, int i, u_int addr_const, char addr, struc
     emit_jeq(0);
 
     if(!ds) load_all_consts(regs[i].regmap_entry,regs[i].was32,regs[i].wasdirty,regs[i].wasconst,i);
-    wb_dirtys(i_regs->regmap_entry,i_regs->was32,i_regs->wasdirty);
+    wb_exception_dirtys(i_regs);
 
     emit_jmp((intptr_t)&do_interrupt);
     set_jump_target(jaddr,(intptr_t)out);
@@ -5528,7 +5565,7 @@ static void cop0_assemble(int i,struct regstat *i_regs)
       intptr_t jaddr=(intptr_t)out;
       emit_jeq(0);
       load_all_consts(regs[i].regmap_entry,regs[i].was32,regs[i].wasdirty,regs[i].wasconst,i);
-      wb_dirtys(i_regs->regmap_entry,i_regs->was32,i_regs->wasdirty);
+      wb_exception_dirtys(i_regs);
       emit_jmp((intptr_t)&do_interrupt);
       set_jump_target(jaddr,(intptr_t)out);
     }

--- a/mupen64plus-core/src/device/r4300/new_dynarec/new_dynarec.c
+++ b/mupen64plus-core/src/device/r4300/new_dynarec/new_dynarec.c
@@ -4969,7 +4969,8 @@ static void emit_xkphys_fold(int i,const struct regstat *i_regs,int addr)
   no_fold2=(intptr_t)out;
   emit_jne(0);
   emit_mov(addr,HOST_TEMPREG);
-  emit_orimm(HOST_TEMPREG,0xA0000000,HOST_TEMPREG);
+  emit_orimm(HOST_TEMPREG,0x80000000,HOST_TEMPREG);
+  emit_orimm(HOST_TEMPREG,0x20000000,HOST_TEMPREG);
   emit_writeword(HOST_TEMPREG,(intptr_t)&g_dev.r4300.new_dynarec_hot_state.address);
   done=(intptr_t)out;
   emit_jmp(0);


### PR DESCRIPTION
Three independent defects on aarch64, found while running this core on a
Raspberry Pi 5.

**1. The jump table scan runs off the end**

`genjmp()` bounds its loop with `sizeof(jump_table_symbols)/4`. The elements
are `uintptr_t`, eight bytes here, so it iterates twice as many times as the
table has entries.

**2. The XKPHYS fold emits an immediate aarch64 cannot encode**

`emit_xkphys_fold()` calls `emit_orimm(HOST_TEMPREG, 0xA0000000,
HOST_TEMPREG)`. Bits 31 and 29 are not a contiguous run, so this is not a
valid logical immediate; `genimm()` rejects it and `emit_orimm` takes its
fallback, which asserts `rs != HOST_TEMPREG` and `imm < 65536` — both false
here — then materialises the value into `HOST_TEMPREG`, destroying the source
before reading it. Release builds define `NDEBUG`, so the asserts vanish and
the fold silently emits wrong code for every memory access with a 64-bit base
register.

Setting the two bits separately encodes directly and never reaches the
fallback. x86 pays one extra instruction on a cold path.

**3. Exception paths skip registers `clean_registers()` cleared**

`clean_registers()` deliberately understates `wasdirty`: it clears the bit of
any register the block will rewrite before the next block reads it. That
holds for the fall-through path, not for an exception, which leaves the block
at an arbitrary point. The six exception paths wrote back `wasdirty` verbatim
and handed the interpreter a stale register file.

**Note on verification**: defects 1 and 3 were found from misbehaviour and
confirmed by fixing them. Defect 2 is silent — I found it by reading
`emit_orimm` after the fold landed, and have no reproduction case to offer.