### PR TITLE
Fix three defects in the GLideN64 per-game settings reader

### DIFF
--- a/mupen64plus-video-gliden64/src/mupenplus/Config_mupenplus.cpp
+++ b/mupen64plus-video-gliden64/src/mupenplus/Config_mupenplus.cpp
@@ -77,7 +77,7 @@ void LoadCustomSettings(bool internal)
 	bool found = false;
 	char buffer[256];
 	char* line;
-	FILE* fPtr;
+	FILE* fPtr = NULL;
 	std::transform(myString.begin(), myString.end(), myString.begin(), ::toupper);
 	if (internal) {
 		line = strtok(customini, "\n");
@@ -159,6 +159,9 @@ void LoadCustomSettings(bool internal)
 				break;
 		}
 	}
+
+	if (fPtr != NULL)
+		fclose(fPtr);
 }
 
 extern "C" void Config_LoadConfig()

--- a/mupen64plus-video-gliden64/src/mupenplus/Config_mupenplus.cpp
+++ b/mupen64plus-video-gliden64/src/mupenplus/Config_mupenplus.cpp
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <algorithm>
+#include <vector>
 
 #include "../Config.h"
 #include "../GLideN64.h"
@@ -78,9 +79,12 @@ void LoadCustomSettings(bool internal)
 	char buffer[256];
 	char* line;
 	FILE* fPtr = NULL;
+	/* Keep the copy alive for the whole scan: strtok holds a pointer into it. */
+	std::vector<char> iniCopy;
 	std::transform(myString.begin(), myString.end(), myString.begin(), ::toupper);
 	if (internal) {
-		line = strtok(customini, "\n");
+		iniCopy.assign(customini, customini + strlen(customini) + 1);
+		line = strtok(iniCopy.data(), "\n");
 	} else {
 		const char *pathname = ConfigGetSharedDataFilepath("GLideN64.custom.ini");
 		if (pathname == NULL || (fPtr = fopen(pathname, "rb")) == NULL)

--- a/mupen64plus-video-gliden64/src/mupenplus/Config_mupenplus.cpp
+++ b/mupen64plus-video-gliden64/src/mupenplus/Config_mupenplus.cpp
@@ -103,6 +103,7 @@ void LoadCustomSettings(bool internal)
 					found = true;
 				else
 					found = false;
+				break;
 			}
 			case INI_PROPERTY:
 			{


### PR DESCRIPTION
`LoadCustomSettings()` in `mupenplus/Config_mupenplus.cpp` reads the per-game
settings database, either the copy embedded in the binary or `GLideN64.custom.ini`
from the shared data directory. Three independent defects, one commit each.

**1. The external file is never closed.** `fPtr` is opened when reading from disk
and no `fclose()` follows, so every ROM load leaks a descriptor. The commit also
initialises `fPtr` to `NULL`, because the embedded path never opens anything and
the close has to know that.

**2. `case INI_SECTION` falls through into `case INI_PROPERTY`.** A section header
sets `found` and then immediately runs the property handler with `l.value`
unset — `util.h` fills only `name` for a section. Adding the missing `break`
stops it.

**3. `strtok()` is called directly on the embedded database.** `customini` is the
`static const char[]` from `GLideN64.custom.ini.h`, and `strtok` writes NUL bytes
into whatever it is given. The commit tokenises a `std::vector<char>` copy
instead, declared at function scope so it outlives the scan — `strtok` keeps a
pointer into it for the whole loop.

### Testing

Built and run on aarch64 with a GLES 3.1 driver. `LoadCustomSettings()` runs on
every ROM load, so all three paths are exercised on any launch; per-game settings
continue to apply as before.

Each commit is independent and can be dropped without touching the others.