### PR TITLE
Fix four core options that disagree with the code, and one wrong description

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -2282,12 +2282,17 @@ void update_variables(bool startup)
       EnableFXAA = atoi(var.value);
    }
 
+   /* Declared in libretro_core_options.h under the same guard. Querying it
+    * unconditionally makes the frontend log "Invalid value" on every launch of
+    * a GLES2 build, for an option the core never offered. */
+#ifndef HAVE_OPENGLES2
    var.key = CORE_NAME "-gliden64-MultiSampling";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       MultiSampling = atoi(var.value);
    }
+#endif
 
    var.key = CORE_NAME "-gliden64-EnableLODEmulation";
    var.value = NULL;

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -2496,12 +2496,14 @@ void update_variables(bool startup)
       EnableFragmentDepthWrite = !strcmp(var.value, "False") ? 0 : 1;
    }
 
-   var.key = CORE_NAME "-gliden64-gliden64-EnableShadersStorage";
+#if !defined(VC) && !defined(HAVE_OPENGLES)
+   var.key = CORE_NAME "-gliden64-EnableShadersStorage";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       EnableShadersStorage = !strcmp(var.value, "False") ? 0 : 1;
    }
+#endif
 
    var.key = CORE_NAME "-gliden64-EnableTextureCache";
    var.value = NULL;

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -213,6 +213,8 @@ static uint8_t* cart_data           = NULL;
 static uint32_t cart_size           = 0;
 static uint8_t* disk_data           = NULL;
 static uint32_t disk_size           = 0;
+/* Set from the 64DD Hardware core option, read at content load. */
+static bool     dd_hardware         = false;
 
 static bool     emu_initialized     = false;
 static unsigned initial_boot        = true;
@@ -668,6 +670,14 @@ static void setup_variables(void)
 
 bool is_cartridge_rom(const uint8_t* data)
 {
+   /* With the 64DD Hardware option on, the frontend has declared this a disk
+    * system, so believe it rather than guessing from the dump. The test below
+    * only recognises the JP and US region markers of a D64 image: a development
+    * disk carries DD_REGION_DV, four zero bytes, and a MAME or SDK dump is
+    * identified by its size rather than by anything at offset zero. */
+   if (dd_hardware)
+      return false;
+
    return (data != NULL && *((uint32_t *)data) != 0x16D348E8 && *((uint32_t *)data) != 0x56EE6322);
 }
 
@@ -1558,6 +1568,18 @@ void update_variables(bool startup)
 	  ForceDisableExtraMem = 0;
 	  if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &expvar) && expvar.value)
 		  ForceDisableExtraMem = !strcmp(expvar.value, "disabled") ? 1 : 0;
+
+	  /* 64DD Hardware. Declared in libretro_core_options.h but read nowhere, so
+	   * it did nothing at all. It now decides how content is classified: with it
+	   * on, whatever is loaded goes to the disk drive rather than being guessed
+	   * at from its first four bytes. Startup only, before retro_load_game
+	   * classifies anything. */
+	  struct retro_variable ddvar;
+	  ddvar.key = "parallel-n64-64dd-hardware";
+	  ddvar.value = NULL;
+	  dd_hardware = false;
+	  if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &ddvar) && ddvar.value)
+		  dd_hardware = !strcmp(ddvar.value, "enabled");
   }
 
 #if defined(HAVE_PARALLEL)

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -1563,6 +1563,21 @@ struct retro_core_option_v2_definition option_defs_us[] = {
         "Software"
     },
     {
+        CORE_NAME "-gliden64-GLideN64IniBehaviour",
+        "Per-game settings",
+        NULL,
+        "(GLideN64) When to apply GLideN64's built-in per-game settings. 'late' lets them override your choices below, 'early' lets your choices win, 'disabled' ignores them entirely.",
+        "When to apply GLideN64's built-in per-game settings. 'late' lets them override your choices below, 'early' lets your choices win, 'disabled' ignores them entirely.",
+        "gliden64",
+        {
+            {"late", NULL},
+            {"early", NULL},
+            {"disabled", NULL},
+            { NULL, NULL },
+        },
+        "late"
+    },
+    {
         CORE_NAME "-gliden64-BackgroundMode",
         "Background Mode",
         NULL,

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -1537,8 +1537,8 @@ struct retro_core_option_v2_definition option_defs_us[] = {
         CORE_NAME "-gliden64-EnableCopyColorFromRDRAM",
         "Color buffer from RDRAM",
         NULL,
-        "(GLideN64) Enable color buffer copy from RDRAM. Required for the few titles that draw to the colour buffer with the CPU and expect the GPU to re-upload it (Donkey Kong 64 anti-aliased shadows, some Indiana Jones effects). Default off for the performance cost.",
-        "Enable color buffer copy from RDRAM. Required for the few titles that draw to the colour buffer with the CPU and expect the GPU to re-upload it. Default off for the performance cost.",
+        "(GLideN64) Always copy the color buffer from RDRAM. GLideN64 already does this by itself whenever it detects that the CPU painted the frame the VI is about to show, so this setting only adds a second, unconditional trigger for the titles that detection misses (Donkey Kong 64 anti-aliased shadows, some Indiana Jones effects). Needs Framebuffer Emulation on. Default off for the performance cost.",
+        "Always copy the color buffer from RDRAM, for the titles GLideN64's own CPU-write detection misses. Needs Framebuffer Emulation on. Default off for the performance cost.",
         "gliden64",
         {
             {"False", NULL},


### PR DESCRIPTION
Four core options where the option table and the code that reads it do not
match, plus a description that explains an option in terms of itself. One commit
each.

**1. `64dd-hardware` is declared and never read.** Its key appears in no source
file, so selecting it did nothing at all. It now decides how loaded content is
classified: `is_cartridge_rom()` otherwise guesses from the first four bytes and
recognises only the JP and US region markers of a D64 image, so a development
disk (`DD_REGION_DV`, four zero bytes) or a MAME/SDK dump was always loaded as a
cartridge. Gating inside `is_cartridge_rom()` covers all three call sites.

**2. `GLideN64IniBehaviour` is read and never declared.** `libretro.c` queries the
key, but no entry exists for it, so no frontend can offer it and the query always
falls back to the default.

**3. `EnableShadersStorage` is read under the wrong key.** The query uses
`CORE_NAME "-gliden64-gliden64-EnableShadersStorage"` — `gliden64` twice —
against a declaration of `CORE_NAME "-gliden64-EnableShadersStorage"`, so the
user's choice never reached the variable.

**4. `MultiSampling` is declared under a guard and queried without one.** The
declaration sits inside `#ifndef HAVE_OPENGLES2`; the query does not. A GLES2
build therefore asks the frontend for an option it never offered, which is
logged as `Invalid value` on every launch.

**5. The `EnableCopyColorFromRDRAM` description was misleading.** It said the
option is *required* for titles that paint the frame with the CPU. It is not:
`copyFromRDRAM()` already runs whenever GLideN64 has detected such a write
(`_bCFB`), and the option is only a second, unconditional trigger for the cases
detection misses — and it is skipped entirely when the core supplies the
framebuffer-info API. The description now says that, and notes the option needs
Framebuffer Emulation on: both entry points into `copyFromRDRAM()` are governed
by that flag.

### Testing

Built and run on aarch64 with a GLES 3.1 driver. Items 1 to 3 and 5 are
verifiable by reading the option table next to the code that consumes it. Item 4
only manifests on a GLES2 build, where the `Invalid value` line appears in the
frontend log on every launch.

Each commit is independent; the last is documentation only.