### PR TITLE
Add a GLES 3.x build mode so GLideN64 can be built for GLES targets

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -32,11 +32,13 @@ else
 endif
 
 # GLideN64 needs OpenGL 3.3 Core or OpenGL ES 3.x (UBOs, integer textures,
-# glcorearb.h, etc.) and does not work on GLES2-only targets. The Makefile's
-# GLES=1 switch maps to -DHAVE_OPENGLES2 with no GLES3 path, so force it off
-# there. Other GLES2-only configurations should also unset HAVE_GLIDEN64.
+# glcorearb.h, etc.) and does not work on GLES2-only targets. GLES=1 maps to
+# -DHAVE_OPENGLES2, so force it off there. GLES3=1 selects the GLES 3.x path
+# below and does satisfy GLideN64, so it is left enabled in that case.
 ifeq ($(GLES),1)
+ifneq ($(GLES3),1)
 	HAVE_GLIDEN64 = 0
+endif
 endif
 
 INCFLAGS += -I$(VIDEODIR_GLIDE)/Glitch64/inc
@@ -679,7 +681,12 @@ endif
 endif
 
 ifeq ($(HAVE_OPENGL),1)
-ifeq ($(GLES),1)
+ifeq ($(GLES3),1)
+	# GLES 3.x path. HAVE_OPENGLES3 makes glsm request a GLES3 context and
+	# enables the GLES3 wrappers in glsm.c; without it they compile to stubs.
+	GLFLAGS += -DHAVE_OPENGLES -DHAVE_OPENGLES3 -DDISABLE_3POINT
+	SOURCES_C += $(LIBRETRO_COMM_DIR)/glsym/glsym_es3.c
+else ifeq ($(GLES),1)
 	GLFLAGS += -DHAVE_OPENGLES -DHAVE_OPENGLES2 -DDISABLE_3POINT
 	SOURCES_C += $(LIBRETRO_COMM_DIR)/glsym/glsym_es2.c
 else

--- a/gles2rice/src/OGLES2FragmentShaders.cpp
+++ b/gles2rice/src/OGLES2FragmentShaders.cpp
@@ -26,7 +26,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 GLuint vertexProgram = 9999;
 const char *vertexShader =
 "#version " GLSL_VERSION "\n"
-#if !defined(HAVE_OPENGLES2)
+#if !defined(HAVE_OPENGLES)
 "#define lowp                                               \n"
 "#define mediump                                            \n"
 #endif
@@ -58,7 +58,7 @@ const char *vertexShader =
 
 const char *fragmentHeader =
 "#define saturate(x) clamp( x, 0.0, 1.0 )                   \n"
-#if !defined(HAVE_OPENGLES2)
+#if !defined(HAVE_OPENGLES)
 "#define lowp                                               \n"
 "#define mediump                                            \n"
 #else
@@ -113,7 +113,7 @@ const char *fragmentFooter =
 //Fragment shader for InitCycleCopy
 const char *fragmentCopy =
 "#version " GLSL_VERSION "\n"
-#if !defined(HAVE_OPENGLES2)
+#if !defined(HAVE_OPENGLES)
 "#define lowp                                               \n"
 "#define mediump                                            \n"
 #else
@@ -133,7 +133,7 @@ GLuint copyProgram,copyAlphaLocation;
 //Fragment shader for InitCycleFill
 const char *fragmentFill =
 "#version " GLSL_VERSION "\n"
-#if !defined(HAVE_OPENGLES2)
+#if !defined(HAVE_OPENGLES)
 "#define lowp                                               \n"
 "#define mediump                                            \n"
 #else

--- a/gles2rice/src/osal_opengl.h
+++ b/gles2rice/src/osal_opengl.h
@@ -30,7 +30,7 @@
 
 #include <glsm/glsmsym.h>
 
-#if defined(HAVE_OPENGLES2) // Desktop GL fix
+#if defined(HAVE_OPENGLES) // Desktop GL fix
 #define GLSL_VERSION "100"
 #else
 #define GLSL_VERSION "120"
@@ -47,7 +47,7 @@
 #define VS_FOG                              4
 
 // Constant substitutions
-#ifdef HAVE_OPENGLES2
+#ifdef HAVE_OPENGLES
 #define GL_CLAMP                            GL_CLAMP_TO_EDGE
 #define GL_MAX_TEXTURE_UNITS                GL_MAX_TEXTURE_IMAGE_UNITS
 

--- a/glide2gl/src/Glitch64/glitch64_combiner.c
+++ b/glide2gl/src/Glitch64/glitch64_combiner.c
@@ -112,7 +112,7 @@ static int tex1_combiner_ext = 0;
 static int c_combiner_ext = 0;
 static int a_combiner_ext = 0;
 
-#if defined(HAVE_OPENGLES2) // Desktop GL fix
+#if defined(HAVE_OPENGLES) // Desktop GL fix
 #define GLSL_VERSION "100"
 #else
 #define GLSL_VERSION "120"
@@ -127,7 +127,7 @@ static int a_combiner_ext = 0;
 
 static const char* fragment_shader_header =
 SHADER_HEADER
-#if defined(HAVE_OPENGLES2) // Desktop GL fix
+#if defined(HAVE_OPENGLES) // Desktop GL fix
 "precision lowp float;          \n"
 #else
 "#define highp                  \n"
@@ -361,7 +361,7 @@ static const char* fragment_shader_end =
 
 static const char* vertex_shader =
 SHADER_HEADER
-#if !defined(HAVE_OPENGLES2) // Desktop GL fix
+#if !defined(HAVE_OPENGLES) // Desktop GL fix
 "#define highp                         \n"
 #endif
 "#define Z_MAX 65536.0                 \n"

--- a/glide2gl/src/Glitch64/glitch64_textures.c
+++ b/glide2gl/src/Glitch64/glitch64_textures.c
@@ -195,7 +195,7 @@ static int grTexFormat2GLPackedFmt(GrTexInfo *info, int fmt, int * gltexfmt, int
       *glpixfmt = GL_LUMINANCE_ALPHA;
       *glpackfmt = GL_UNSIGNED_BYTE;
    }
-#ifndef HAVE_OPENGLES2
+#ifndef HAVE_OPENGLES
    else if (packed_pixels_support)
    {
       switch(fmt)
@@ -333,7 +333,7 @@ static int grTexFormat2GLPackedFmt(GrTexInfo *info, int fmt, int * gltexfmt, int
             *glpackfmt = GL_UNSIGNED_BYTE;
             break;
          case GR_TEXFMT_ARGB_8888:
-#ifdef HAVE_OPENGLES2
+#ifdef HAVE_OPENGLES
             if (bgra8888_support)
             {
                factor = 4;

--- a/libretro-common/glsm/glsm.c
+++ b/libretro-common/glsm/glsm.c
@@ -2991,9 +2991,7 @@ void rglDrawElementsBaseVertex(GLenum mode, GLsizei count, GLenum type,
 
 void rglTexParameteri( GLenum target, GLenum pname, GLint param )
 {
-#if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) && defined(HAVE_OPENGLES3)
    return glTexParameteri(target, pname, param);
-#endif
 }
 
 void rglTexImage2D( GLenum target, GLint level,
@@ -3002,46 +3000,32 @@ void rglTexImage2D( GLenum target, GLint level,
                     GLint border, GLenum format, GLenum type,
                     const GLvoid *pixels )
 {
-#if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) && defined(HAVE_OPENGLES3)
    return glTexImage2D(target, level, internalFormat, width, height, border, format, type, pixels);
-#endif
 }
 
 void rglGetIntegerv (GLenum pname, GLint *data)
 {
-#if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) && defined(HAVE_OPENGLES3)
    return glGetIntegerv(pname, data);
-#endif
 }
 
 void rglFlush(void)
 {
-#if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) && defined(HAVE_OPENGLES3)
    glFlush();
-#endif
 }
 
 const GLubyte* rglGetString (GLenum name)
 {
-#if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) && defined(HAVE_OPENGLES3)
    return glGetString(name);
-#else
-   return NULL;
-#endif
 }
 
 void rglGetTexParameteriv (GLenum target, GLenum pname, GLint *params)
 {
-#if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) && defined(HAVE_OPENGLES3)
    return glGetTexParameteriv(target, pname, params);
-#endif
 }
 
 void rglGetFloatv (GLenum pname, GLfloat *data)
 {
-#if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) && defined(HAVE_OPENGLES3)
    return glGetFloatv(pname, data);
-#endif
 }
 
 /* GLSM-side */

--- a/libretro-common/include/glsym/glsym_es3.h
+++ b/libretro-common/include/glsym/glsym_es3.h
@@ -3,16 +3,16 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-#ifdef GL_APIENTRY
-typedef void (GL_APIENTRY *RGLGENGLDEBUGPROC)(GLenum, GLenum, GLuint, GLenum, GLsizei, const GLchar*, GLvoid*);
-typedef void (GL_APIENTRY *RGLGENGLDEBUGPROCKHR)(GLenum, GLenum, GLuint, GLenum, GLsizei, const GLchar*, GLvoid*);
-#else
 #ifndef APIENTRY
 #define APIENTRY
 #endif
 #ifndef APIENTRYP
 #define APIENTRYP APIENTRY *
 #endif
+#ifdef GL_APIENTRY
+typedef void (GL_APIENTRY *RGLGENGLDEBUGPROC)(GLenum, GLenum, GLuint, GLenum, GLsizei, const GLchar*, GLvoid*);
+typedef void (GL_APIENTRY *RGLGENGLDEBUGPROCKHR)(GLenum, GLenum, GLuint, GLenum, GLsizei, const GLchar*, GLvoid*);
+#else
 typedef void (APIENTRY *RGLGENGLDEBUGPROCARB)(GLenum, GLenum, GLuint, GLenum, GLsizei, const GLchar*, GLvoid*);
 typedef void (APIENTRY *RGLGENGLDEBUGPROC)(GLenum, GLenum, GLuint, GLenum, GLsizei, const GLchar*, GLvoid*);
 #endif

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -1679,7 +1679,11 @@ struct retro_core_option_v2_definition option_defs_us[] = {
             {"True", NULL},
             { NULL, NULL },
         },
-#ifdef HAVE_OPENGLES
+/* GLES2 only. GLSL ES 1.00 has no gl_FragDepth without GL_EXT_frag_depth, and
+ * GLideN64 declines to emit writeDepth() there at all, so the setting cannot
+ * work on GLES2. GLSL ES 3.00 makes gl_FragDepth core, and a GLES 3.x target is
+ * no less capable than the desktop one this already defaults to True for. */
+#ifdef HAVE_OPENGLES2
         "False"
 #else
         "True"

--- a/mupen64plus-video-gliden64/src/Graphics/OpenGLContext/GLFunctions.h
+++ b/mupen64plus-video-gliden64/src/Graphics/OpenGLContext/GLFunctions.h
@@ -16,6 +16,15 @@
 #include <GL/glcorearb.h>
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
+#elif defined(HAVE_OPENGLES3)
+/* Desktop <GL/gl.h> must stay out: it declares glEnable and friends as real
+ * functions, and glsmsym.h has already turned those names into macros.
+ * glcorearb.h has PFNGL*PROC typedefs this file needs and declares
+ * nothing itself.  The GLES headers have to arrive here, before the
+ * glX -> g_glX macros below, or their prototypes expand into bogus
+ * declarations. */
+#include <glsym/rglgen_headers.h>
+#include <GL/glcorearb.h>
 #elif defined(OS_MAC_OS_X)
 #include <OpenGL/OpenGL.h>
 #include <stddef.h>


### PR DESCRIPTION
GLideN64 needs OpenGL 3.3 Core or OpenGL ES 3.x. The Makefile can only express
GLES2 — `GLES=1` maps to `-DHAVE_OPENGLES2` with no GLES3 path — so
`Makefile.common` force-unsets `HAVE_GLIDEN64` for every GLES target. There is
currently no way to build the plugin for hardware that does support GLES 3.x,
even though `GLES3` already appears in that file as a comment describing the
missing branch.

This adds the missing switch. The mode is selected with `GLES3=1` and defines
`HAVE_OPENGLES` and `HAVE_OPENGLES3` without `HAVE_OPENGLES2`.

The four preparatory commits come first so that every intermediate state builds
exactly as master does, and the mode itself is last:

1. **`glsym_es3.h`** — `APIENTRY`/`APIENTRYP` are used before they are defined.
   Inert today: only `glsym_es2.c` is compiled.
2. **`glsm.c`** — seven core GL entry points (`glTexParameteri`, `glTexImage2D`,
   `glGetIntegerv`, `glFlush`, `glGetString`, `glGetTexParameteriv`,
   `glGetFloatv`) are compiled out under
   `HAVE_OPENGL || (HAVE_OPENGLES && HAVE_OPENGLES3)`. They are core in every
   GLES profile. No behaviour change today: the condition is already true on
   desktop, and on GLES the only caller is GLideN64, which is not built.
3. **rice** and 4. **glide2gl** — both test `HAVE_OPENGLES2` where they mean
   "are we on GLES". Equivalent today, since the two macros are defined
   together; they would send a GLES 3.x target down the desktop path once they
   are not.
5. **The mode itself** — `Makefile.common` gains a `GLES3=1` branch and stops
   unsetting `HAVE_GLIDEN64` for it; `GLFunctions.h` gains an
   `#elif defined(HAVE_OPENGLES3)` branch alongside the existing `EGL` one.
6. **The fragment depth write default** — currently `False` under
   `#ifdef HAVE_OPENGLES`, but what it guards against is GLES2 specifically:
   GLSL ES 1.00 has no `gl_FragDepth` without `GL_EXT_frag_depth`, and GLideN64
   emits neither `writeDepth()` nor the `fragDepth` variable when GLInfo reports
   GLES2. GLSL ES 3.00 makes it core. Without this, a GLES 3.x build ships with
   depth write off on hardware that supports it.

### Testing

**GLES 3.x, aarch64 (Raspberry Pi 5, Mesa V3D):** built with `GLES3=1` and run
with GLideN64 as the graphics plugin. Titles exercising framebuffer emulation,
depth-buffer readback and CPU-painted frames render correctly.

**GLES2, ARM32 (Raspberry Pi 3, Mesa 24.2.6, `OpenGL ES 2.0`):** built without
`GLES3=1` to confirm the new branch stays dormant. GLideN64 is absent from the
resulting binary — `writeDepth`, `uRenderTarget`, `uDepthScale`,
`GraphicsDrawer` and `FrameBufferList` all yield zero matches, while rice,
glide64 and glN64 are present as before — and the object is 3.3 MB against
7.9 MB for the GLES 3.x build. Games run. Runtime was checked with the cached
interpreter, because the ari64 dynarec currently fails on ARM32 with
"Compile at bogus memory address" before any of this series is reached; that is
unrelated and will be reported separately.

Commits 1, 2 and 6 touch code a GLES2 build does not compile — `glsym_es3.c` is
not in its sources, and `HAVE_GLIDEN64` is 0 there, which removes the only
caller of the `glsm.c` entry points and the whole shader builder. Commits 3 and
4 do change compiled code on GLES2, where rice and glide2gl are built, and rice
was the active plugin during the ARM32 run.

The last commit is a default rather than a build change and can be dropped
without affecting the rest.