### PR TITLE
Fix the ari64 dynarec on arm32: boot vector re-entry and a split stop flag

### DIFF
--- a/mupen64plus-core/src/device/r4300/new_dynarec/arm/linkage_arm.S
+++ b/mupen64plus-core/src/device/r4300/new_dynarec/arm/linkage_arm.S
@@ -80,7 +80,6 @@ fp_stop                = offsetof_struct_new_dynarec_hot_state_stop
 TEXT_SECTION
 
     .align   2
-    .outptr_offset  : .word out-(.outptr_pic+8)
     .savedcontextptr_offset  : .word g_dev + device_r4300_new_dynarec_hot_state_dynarec_local + fp_saved_context -(.savedcontextptr_pic+8)
 
 GLOBAL_FUNCTION(jump_vaddr_r0):
@@ -204,17 +203,12 @@ GLOBAL_FUNCTION(new_dyna_start):
     ldr    r12, .savedcontextptr_offset
 .savedcontextptr_pic:
     add    r12, pc, r12
-    ldr    r1, .outptr_offset
-.outptr_pic:
-    add    r1, pc, r1
-    mov    r0, #0xa4000000
     stmia  r12, {r4, r5, r6, r7, r8, r9, sl, fp, lr}
     sub    fp, r12, #fp_saved_context
-    ldr    r4, [r1]
-    add    r0, r0, #0x40
-    bl     new_recompile_block
+    ldr    r0, [fp, #fp_pcaddr]
+    bl     get_addr_ht
     ldr    r10, [fp, #fp_cycle_count]
-    mov    pc, r4
+    mov    pc, r0
 
 GLOBAL_FUNCTION(invalidate_addr_r0):
     stmia  fp, {r0, r1, r2, r3, r12, lr}

--- a/mupen64plus-core/src/device/r4300/r4300.h
+++ b/mupen64plus-core/src/device/r4300/r4300.h
@@ -74,7 +74,19 @@ extern int g_cp0_cycle_count;
 #define mupencorereg  (g_dev.r4300.regs)
 #define hi            (g_dev.r4300.hi)
 #define lo            (g_dev.r4300.lo)
+#ifdef NEW_DYNAREC
+/* ARM32 reaches this branch: it is neither _M_X64 nor aarch64, but it *does*
+ * build the ari64 dynarec, whose linkage reads the stop flag out of
+ * new_dynarec_hot_state (fp_stop in linkage_arm.S). Aliasing mupencorestop to
+ * the base-struct field there splits the flag in two: retro_return sets both
+ * (directly and through r4300_stop()), main_run clears only the hot-state one,
+ * and retro_return's "if (mupencorestop) return 0" early-out then sees a stop
+ * that is never cleared -- so from the second slice on it never arms another
+ * frame break, main_run never returns and retro_run blocks. */
+#define mupencorestop (g_dev.r4300.new_dynarec_hot_state.stop)
+#else
 #define mupencorestop (g_dev.r4300.stop)
+#endif
 #endif
 #else
 /* aarch64: the unified new_dynarec.c arm64 path uses the same


### PR DESCRIPTION
Two defects, found in sequence: the second was invisible until the first was
fixed. Both are confined to the ari64 path on 32-bit ARM; no other
architecture is touched.

### Testing

Raspberry Pi 3, `platform=unix-rpi3-mesa` (`WITH_DYNAREC=arm`,
`-DNEW_DYNAREC=3`), Mario Kart 64 and Resident Evil 2.

- Before: `Compile at bogus memory address: a4002000` at boot, every run,
  with an identical block sequence each time.
- After the first commit: the game boots and submits display lists, but only
  one frame is ever produced -- no picture, no input, `killall` required.
- After both: the games run.

The cached interpreter was unaffected throughout, which is what isolated both
defects to the dynarec -- the same signature that isolated the arm64 case in
0295648c.