### PR TITLE
RSP: deliver a completing task's break exactly once

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -487,12 +487,11 @@ static void core_settings_autoselect_rsp_plugin(void)
 
    rsp_plugin = RSP_HLE;
 
-   if (
-          (!strcmp((const char*)ROM_HEADER.Name, "GAUNTLET LEGENDS"))
-      )
-   {
-      rsp_plugin = RSP_CXD4;
-   }
+   /* No hardcoded RSP routing for Gauntlet Legends: rsp-hle detects its
+    * streaming microcode and serves it (angrylion), or declares itself
+    * unable and the task falls back to the LLE plugin (GLideN64). The old
+    * RSP_CXD4 override predated the streaming support and forced the one
+    * path that cannot work under either renderer. */
 
    if (!strcmp((const char*)ROM_HEADER.Name, "CONKER BFD"))
       rsp_plugin = RSP_HLE;

--- a/mupen64plus-core/src/device/rcp/rsp/rsp_core.c
+++ b/mupen64plus-core/src/device/rcp/rsp/rsp_core.c
@@ -477,16 +477,31 @@ void do_SP_Task(struct rsp_core* sp)
     else if (sp->mi->regs[MI_INTR_REG] & MI_INTR_SP)
     {
         cp0_update_count(sp->mi->r4300);
-        /* Leave MI_INTR_SP asserted for the CPU's handler to find.
-         * Consuming it here scheduled the event and then removed the
-         * only evidence of where it came from, so a handler that
-         * dispatches on MI_INTR_REG - as libdragon's does - saw an
-         * interrupt with no source and ignored it.  Its rspq syncpoints
-         * are signalled exactly this way, so every wait on one timed
-         * out.  The incomplete-task branch above already keeps the bit
-         * for the same reason; the completing branch has to as well.
-         * The CPU clears it by writing SP_STATUS with SP_CLR_INTR,
-         * which update_sp_status already handles. */
+        /* A completing task must deliver its break ONCE, at
+         * +sp_delay_time, with the status bits and the interrupt
+         * paired: the tail below clears TASKDONE|BROKE|HALT and the
+         * deferred event re-exposes them together with the raise.
+         * Consume the bit rsp_break set so the break does not ALSO
+         * deliver an early edge now: status-polling games acknowledge
+         * that early interrupt, find no status, and dismiss it, while
+         * schedulers that trust the interrupt count it twice --
+         * Gauntlet Legends' RSP scheduler pairs completion messages
+         * with in-flight tasks positionally, retired one task too many
+         * on the duplicate, popped an empty slot without a NULL check
+         * and parked its dispatcher in a blocking osSendMesg on a NULL
+         * queue: the scene-change deadlock. The same duplicate also
+         * deadlocked its cxd4 LLE fallback at the Midway logo, closing
+         * the GLideN64 path entirely, and produced Lego Racers' and
+         * Paperboy's random polygons (display lists reused mid-build).
+         * Mid-task raises are not affected: a persistent task
+         * (libdragon's rspq syncpoints, the BOSS WAITSIGNAL handshake)
+         * goes through the incomplete branch above, which keeps the
+         * bit asserted for the CPU to service. Clear the cause line
+         * too so the swallowed early edge cannot deliver as a
+         * source-less interrupt. */
+        sp->mi->regs[MI_INTR_REG] &= ~MI_INTR_SP;
+        r4300_check_interrupt(sp->mi->r4300, CP0_CAUSE_IP2,
+            sp->mi->regs[MI_INTR_REG] & sp->mi->regs[MI_INTR_MASK_REG]);
         add_interrupt_event(&sp->mi->r4300->cp0, SP_INT, sp_delay_time);
     }
     if ((sp->regs[SP_STATUS_REG] & (SP_STATUS_HALT | SP_STATUS_BROKE)))

--- a/mupen64plus-rsp-hle/src/hle.c
+++ b/mupen64plus-rsp-hle/src/hle.c
@@ -472,8 +472,15 @@ static void streaming_gfx_task(struct hle_t* hle)
     resume = l_streaming_gfx_running
           || ((*dmem_u32(hle, TASK_FLAGS) & 1) != 0);
 
-    if (!resume) {
-        /* the microcode clears SIG1 and SIG2 at task start */
+    if (!l_streaming_gfx_running || (*dmem_u32(hle, TASK_FLAGS) & 1)) {
+        /* every real launch of the task runs the microcode's boot, which
+         * clears SIG1 and SIG2 -- the fresh start AND the relaunch of a
+         * yielded task. Only the plain re-dispatch of a suspended walk
+         * (l_streaming_gfx_running set, no launch in between) keeps the
+         * signals untouched. Without the clear on the yielded relaunch,
+         * SIG1 survives the yield, and once the resumed task completes,
+         * osSpTaskYielded reads the stale SIG1 and the game files the
+         * completion as another yield. */
         *hle->sp_status &= ~(SP_STATUS_SIG1 | SP_STATUS_TASKDONE);
     }
 
@@ -499,8 +506,11 @@ static void streaming_gfx_task(struct hle_t* hle)
 
     if (*hle->sp_status & SP_STATUS_SIG0) {
         /* the CPU requested a yield: answer with the microcode's yield
-         * status (SET_SIG1|SET_SIG2, break). The walker state stays
-         * saved; the relaunch arrives with OS_TASK_YIELDED set. */
+         * status (SET_SIG1|SET_SIG2, break). SIG0 stays set -- the
+         * game's osSpTaskYielded still needs to see the request, and
+         * the CPU clears it itself on the relaunch (osSpTaskLoad). The
+         * walker state stays saved; the relaunch arrives with
+         * OS_TASK_YIELDED set. */
         rsp_break(hle, SP_STATUS_SIG1 | SP_STATUS_TASKDONE);
         return;
     }


### PR DESCRIPTION
When a task completes, `rsp_break` raises the SP interrupt immediately, and
`do_SP_Task`'s completing branch then schedules the deferred SP_INT event that
replays the same status bits and raises again at +sp_delay_time. One break,
two interrupt edges. Status-polling games survive the duplicate, but game
schedulers that trust the interrupt itself count both edges.

Witnessed consequences:

- **Gauntlet Legends** pairs completion messages with in-flight tasks
  positionally. The duplicate retired one task too many, popped an empty slot
  without a NULL check and parked the dispatcher thread in a blocking
  `osSendMesg` on a NULL queue — the well-known scene-change deadlock, with
  the last audio buffers looping forever. The same duplicate also deadlocked
  the game's LLE fallback at the Midway logo.
- **Lego Racers** and **Paperboy** rebuilt display lists that the duplicate
  completion handed back mid-build, drawing random polygons.

The fix (first commit) consumes MI_INTR_SP in the completing branch and drops
the cause line, so the break's early edge is withdrawn and the deferred event
delivers the status bits and the interrupt together, exactly once. Mid-task
raises are not affected: persistent tasks (libdragon's rspq syncpoints, BOSS
WAITSIGNAL handshakes) go through the incomplete branch, which keeps the bit
asserted for the CPU to service.

The two follow-up commits build on it:

- **rsp-hle**: the streaming graphics task cleared SIG1/SIG2 only on a fresh
  start, not when a yielded task was relaunched, so a stale SIG1 made
  `osSpTaskYielded` misfile a completion as another yield and the game waited
  forever for a relaunch. The clear now happens on every real launch, matching
  the microcode's boot behavior.
- **libretro**: with both of the above fixed, the hardcoded cxd4 routing for
  Gauntlet Legends only robbed angrylion of the HLE fast path; normal
  autoselect now does the right thing (HLE serves the streaming microcode, or
  the task falls back to the configured LLE plugin under GLideN64). The
  override is removed.

Tested on aarch64 (Raspberry Pi 5, GLES 3.1): Gauntlet Legends is playable
under both angrylion and GLideN64, Lego Racers and Paperboy no longer draw
stray polygons, and no regression was observed across a full romset sweep.