### PR TITLE
new_dynarec: accumulate the 64-bit register mask in ERET_new

### DIFF
--- a/mupen64plus-core/src/device/r4300/new_dynarec/new_dynarec.c
+++ b/mupen64plus-core/src/device/r4300/new_dynarec/new_dynarec.c
@@ -1909,7 +1909,7 @@ void* ERET_new(void)
     {
         uint32_t is64 = 0;
         for(int i=0;i<32;i++)
-            is64 = (((int)(state->regs[i]>>32)^((int)state->regs[i]>>31))!=0)<<i;
+            is64 |= (((int)(state->regs[i]>>32)^((int)state->regs[i]>>31))!=0)<<i;
 
         is64 |= (((int)(state->hi>>32)^((int)state->hi>>31))!=0);
         is64 |= (((int)(state->lo>>32)^((int)state->lo>>31))!=0);


### PR DESCRIPTION
Commit 3e23d249 rewrote the loop that rebuilds the `is64` mask on exception
return and turned the `|=` into a plain assignment. Every iteration threw away
the previous registers' bits, so only r31's flag (plus hi/lo) survived by the
time the mask was used: registers holding live 64-bit values were treated as
32-bit after an ERET, and their upper halves were silently dropped.

This restores the accumulation. One-line fix, no behavior change for code that
never runs 64-bit values across an exception return.