### PR TITLE
libretro: wire up the GLideN64 overscan crop options

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -2564,6 +2564,41 @@ void update_variables(bool startup)
       EnableCopyAuxToRDRAM = !strcmp(var.value, "False") ? 0 : 1;
    }
 
+   var.key = CORE_NAME "-gliden64-EnableOverscan";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      EnableOverscan = !strcmp(var.value, "Enabled") ? 1 : 0;
+   }
+
+   var.key = CORE_NAME "-gliden64-OverscanTop";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      OverscanTop = atoi(var.value);
+   }
+
+   var.key = CORE_NAME "-gliden64-OverscanLeft";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      OverscanLeft = atoi(var.value);
+   }
+
+   var.key = CORE_NAME "-gliden64-OverscanRight";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      OverscanRight = atoi(var.value);
+   }
+
+   var.key = CORE_NAME "-gliden64-OverscanBottom";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      OverscanBottom = atoi(var.value);
+   }
+
    var.key = CORE_NAME "-gliden64-GLideN64IniBehaviour";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -1759,7 +1759,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
             {"Enabled", NULL},
             { NULL, NULL },
         },
-        "Enabled"
+        "Disabled"
     },
     {
         CORE_NAME "-gliden64-OverscanTop",


### PR DESCRIPTION
The five `parallel-n64-gliden64-EnableOverscan` / `OverscanTop` / `Left` /
`Right` / `Bottom` core options were declared in `libretro_core_options.h` and
fully plumbed on the GLideN64 side (`Config_mupenplus.cpp` feeds them into
`frameBufferEmulation.overscan*`, consumed by `OverscanBuffer`), but
`update_variables()` never fetched them — the globals kept their zero
initialisers and the options had no effect. This fetches them like the
neighbouring GLideN64 options.

The declared default moves from `Enabled` to `Disabled` to match the behaviour
the dead options always had: no extra blit is imposed by default, cropping
remains a per-game opt-in.

Why it matters: some games deliberately leave their overscan margin unpainted
and rely on CRT overscan to hide the garbage. Pilotwings 64's source even names
the constants — 8 rows top, 18 bottom, 10 left/right. These options let the
frontend crop that margin the way a CRT did.

Tested on aarch64 (Raspberry Pi 5, GLES 3.1): with the options disabled,
output is unchanged; enabling a Top/Bottom/Left/Right crop on Pilotwings 64
removes the unpainted band.