### PR TITLE
GLideN64: keep the rendered frame when CPU writes hit unsynchronized RDRAM

### DIFF
--- a/mupen64plus-video-gliden64/src/VI.cpp
+++ b/mupen64plus-video-gliden64/src/VI.cpp
@@ -143,9 +143,22 @@ void VI_UpdateScreen()
 		} else if (!FBInfo::fbInfo.isSupported() &&
 				 (config.generalEmulation.hacks & hack_RE2) == 0 &&
 				 !pBuffer->isValid(true)) {
-			gDP.changed |= CHANGED_CPU_FB_WRITE;
-			if (config.frameBufferEmulation.copyToRDRAM == 0 && (config.generalEmulation.hacks & hack_subscreen) == 0)
+			if (!pBuffer->m_cfb && !pBuffer->m_copiedToRdram &&
+				(config.generalEmulation.hacks & hack_subscreen) == 0) {
+				/* CPU writes landed under a buffer the RDP rendered. That
+				 * buffer's RDRAM was never synchronized, so it does not hold
+				 * the picture on screen -- handing the frame to the
+				 * CPU-framebuffer path would tear the buffer down and present
+				 * that stale memory. The console shows the last rendered
+				 * picture here, so keep presenting the texture, and refresh
+				 * the validity snapshot so the check settles once the writes
+				 * stop. */
 				pBuffer->copyRdram();
+			} else {
+				gDP.changed |= CHANGED_CPU_FB_WRITE;
+				if (config.frameBufferEmulation.copyToRDRAM == 0 && (config.generalEmulation.hacks & hack_subscreen) == 0)
+					pBuffer->copyRdram();
+			}
 		}
 
 		const bool bCFB = (gDP.changed&CHANGED_CPU_FB_WRITE) == CHANGED_CPU_FB_WRITE;


### PR DESCRIPTION
When CPU writes invalidated a buffer the RDP had rendered, `VI_UpdateScreen`
handed the frame to the CPU-framebuffer path unconditionally: `saveBuffer` tore
the rendered buffer down to create a copy aligned to the VI origin, and that
copy uploaded RDRAM that — with copyToRDRAM asynchronous and the game not using
fbInfo — had never received a rendered frame, and still held whatever the
memory contained before the buffer existed.

Pilotwings 64 made it visible on every menu validation: the game uses the
displayed frame's RDRAM as load scratch during screen changes, so the takeover
presented boot-time residue for the few frames the load lasts — a band of noise
flashing over an otherwise black screen. Probed frame by frame: five
transitions, five takeovers, each tearing down the live buffer (`saveBuffer`'s
non-overlap removal) and serving a stale copy created at boot.

The fix keeps the rendered texture on screen when the buffer's RDRAM was never
synchronized, and refreshes the validity snapshot so the check settles once the
writes stop. That matches the console: RDRAM there holds the last rendered
picture, so the freeze frame is the authentic behaviour.

The scope is deliberately narrow — buffers whose RDRAM *was* synchronized keep
the CPU-framebuffer path, as do genuine CPU-drawn screens at fresh addresses
(their buffers are created by that path in the first place) and `hack_subscreen`
games.

Tested on aarch64 (Raspberry Pi 5, GLES 3.1): the Pilotwings 64 flash is gone,
and no regression was observed on the games known to use the CPU-framebuffer
path (Monster Truck Madness menus, Resident Evil 2, Mario Kart 64 podium).