### PR TITLE
GLideN64: make Resident Evil 2 playable

### DIFF
--- a/mupen64plus-video-gliden64/src/BufferCopy/RDRAMtoColorBuffer.cpp
+++ b/mupen64plus-video-gliden64/src/BufferCopy/RDRAMtoColorBuffer.cpp
@@ -308,10 +308,53 @@ void RDRAMtoColorBuffer::copyFromRDRAM(u32 _address, bool _bCFB)
 	if (m_pCurBuffer->m_startAddress == _address && gDP.colorImage.changed != 0)
 		return;
 
+	/* Resident Evil 2: do not paint RDRAM over a buffer the RDP owns.
+	 *
+	 * The guard above is meant to stop exactly that, but it only fires when the
+	 * address matches the start of the buffer. In this game's interlaced
+	 * cutscenes the VI origin sits a line inside the page -- 0063e6f8 against a
+	 * buffer at 0063e000 -- so the addresses differ and the guard is bypassed.
+	 *
+	 * Measured, frame by frame: the RDP draws roughly one frame in nine, and this
+	 * copy runs on every one of them, after the drawing. It covers 416 rows while
+	 * RDRAM only holds 334, so the rows below that are whatever memory happens to
+	 * contain, painted over what was just drawn. The subtitles start at row 333.
+	 *
+	 * m_cfb is cleared by setBufferChanged as soon as the RDP draws into a
+	 * buffer, so !_bCFB && !m_cfb reads as: an RDRAM copy nobody asked for, into
+	 * a buffer the RDP is drawing. The film still reaches the screen through the
+	 * genuine CFB uploads, which keep their path. */
+	if ((config.generalEmulation.hacks & hack_RE2) != 0 && !_bCFB && !m_pCurBuffer->m_cfb)
+		return;
+
+	/* Resident Evil 2: never upload past the buffer's own height.
+	 *
+	 * When the address does not match the buffer start, the height taken here is
+	 * VI_GetMaxBufferHeight -- a global ceiling rather than anything about this
+	 * buffer. Read back from the GPU on the pre-rendered rooms, the band of noise
+	 * under the picture measures out to m_height, the tallest row the RDP ever
+	 * rasterised into this buffer, which outlives the scene that set it:
+	 *
+	 *   432-wide room: picture ends at texture row 436, noise runs 437..488,
+	 *                  488 / 1.4815 = 329 against the 295 rows shown;
+	 *   340-wide room: picture ends at 442, noise runs 471..790,
+	 *                  790 / 1.882  = 420 against the 235 rows shown.
+	 *
+	 * Both bands begin where the picture stops and end at m_height, and the twin
+	 * buffer (0076a000) is clean black over the same rows, so this is fresh paint
+	 * from the upload and not stale texture content. RDRAM holds the picture and
+	 * nothing after it. */
+	u32 maxHeight = VI_GetMaxBufferHeight(m_pCurBuffer->m_width);
+	if ((config.generalEmulation.hacks & hack_RE2) != 0) {
+		if (m_pCurBuffer->m_height > 0)
+			maxHeight = std::min(maxHeight, (u32)m_pCurBuffer->m_height);
+		maxHeight = std::min(maxHeight, (u32)VI.real_height);
+	}
+
 	const u32 height = cutHeight(m_pCurBuffer->m_startAddress,
 		m_pCurBuffer->m_startAddress == _address ?
 			VI.real_height :
-			VI_GetMaxBufferHeight(m_pCurBuffer->m_width), m_pCurBuffer->m_width << m_pCurBuffer->m_size >> 1);
+			maxHeight, m_pCurBuffer->m_width << m_pCurBuffer->m_size >> 1);
 	if (height == 0)
 		return;
 
@@ -323,8 +366,17 @@ void RDRAMtoColorBuffer::copyFromRDRAM(FrameBuffer * _pBuffer)
 	if (_pBuffer == nullptr)
 		return;
 	m_pCurBuffer = _pBuffer;
+	/* Resident Evil 2: same limit as the address form above.
+	 *
+	 * This overload takes VI_GetMaxBufferHeight bare -- 290 for a 320-wide buffer
+	 * and 580 above that. On the boot screens the noise ends at texture row 579
+	 * of 580, exactly that ceiling, so this call is the one that paints it there.
+	 * Bound it to what the VI actually shows. */
+	u32 uploadHeight = VI_GetMaxBufferHeight(m_pCurBuffer->m_width);
+	if ((config.generalEmulation.hacks & hack_RE2) != 0 && VI.real_height > 0)
+		uploadHeight = std::min(uploadHeight, (u32)VI.real_height);
 	const u32 height = cutHeight(m_pCurBuffer->m_startAddress,
-		VI_GetMaxBufferHeight(m_pCurBuffer->m_width), m_pCurBuffer->m_width << m_pCurBuffer->m_size >> 1);
+		uploadHeight, m_pCurBuffer->m_width << m_pCurBuffer->m_size >> 1);
 	_copyFromRDRAM(height, true);
 }
 

--- a/mupen64plus-video-gliden64/src/BufferCopy/RDRAMtoColorBuffer.cpp
+++ b/mupen64plus-video-gliden64/src/BufferCopy/RDRAMtoColorBuffer.cpp
@@ -344,16 +344,40 @@ void RDRAMtoColorBuffer::copyFromRDRAM(u32 _address, bool _bCFB)
 	 * buffer (0076a000) is clean black over the same rows, so this is fresh paint
 	 * from the upload and not stale texture content. RDRAM holds the picture and
 	 * nothing after it. */
+	/* Resident Evil 2: fill a little past the VI's visible height.
+	 *
+	 * Read back from the GPU, the cutscene buffer is painted to exactly
+	 * VI.real_height rows and not one more -- 136 in the 264x136 mode, which the
+	 * capture confirms at texture row 329 over a scale of 2.4242 -- and the
+	 * second line of dialogue is sliced through its glyphs at that boundary.
+	 *
+	 * Four rows, measured from the buffer captures rather than chosen: the text
+	 * ends at N64 row 137.8 against a visible height of 136, and stale texture
+	 * content begins at 140.3. Sixteen was the first attempt and stages four rows
+	 * of that stale content for nothing.
+	 *
+	 * Not VI_GetMaxBufferHeight: that adds 154 unwritten rows in this mode, which
+	 * is where the band of noise under the picture came from. Anything below the
+	 * picture is content nobody wrote this scene, so the margin has to stay
+	 * small. */
+	u32 fillHeight = VI.real_height;
+	if ((config.generalEmulation.hacks & hack_RE2) != 0)
+		fillHeight = std::min((u32)VI_GetMaxBufferHeight(m_pCurBuffer->m_width),
+		                      fillHeight + 4u);
+
 	u32 maxHeight = VI_GetMaxBufferHeight(m_pCurBuffer->m_width);
 	if ((config.generalEmulation.hacks & hack_RE2) != 0) {
 		if (m_pCurBuffer->m_height > 0)
 			maxHeight = std::min(maxHeight, (u32)m_pCurBuffer->m_height);
-		maxHeight = std::min(maxHeight, (u32)VI.real_height);
+		/* fillHeight, not VI.real_height: the confirmed subtitle fix lives in
+		 * those four rows, and the VI origin sits a line inside the page in the
+		 * cutscenes, so it may well be this branch that runs there. */
+		maxHeight = std::min(maxHeight, fillHeight);
 	}
 
 	const u32 height = cutHeight(m_pCurBuffer->m_startAddress,
 		m_pCurBuffer->m_startAddress == _address ?
-			VI.real_height :
+			fillHeight :
 			maxHeight, m_pCurBuffer->m_width << m_pCurBuffer->m_size >> 1);
 	if (height == 0)
 		return;
@@ -374,7 +398,7 @@ void RDRAMtoColorBuffer::copyFromRDRAM(FrameBuffer * _pBuffer)
 	 * Bound it to what the VI actually shows. */
 	u32 uploadHeight = VI_GetMaxBufferHeight(m_pCurBuffer->m_width);
 	if ((config.generalEmulation.hacks & hack_RE2) != 0 && VI.real_height > 0)
-		uploadHeight = std::min(uploadHeight, (u32)VI.real_height);
+		uploadHeight = std::min(uploadHeight, VI.real_height + 4u);
 	const u32 height = cutHeight(m_pCurBuffer->m_startAddress,
 		uploadHeight, m_pCurBuffer->m_width << m_pCurBuffer->m_size >> 1);
 	_copyFromRDRAM(height, true);

--- a/mupen64plus-video-gliden64/src/FrameBuffer.cpp
+++ b/mupen64plus-video-gliden64/src/FrameBuffer.cpp
@@ -1404,6 +1404,26 @@ void FrameBufferList::renderBuffer()
 	srcWidth = min(rdpRes.vi_width, (rdpRes.vi_hres * rdpRes.vi_x_add) >> 10);
 	srcHeight = rdpRes.vi_width * ((rdpRes.vi_vres*rdpRes.vi_y_add + rdpRes.vi_y_start) >> 10) / pBuffer->m_width;
 
+	/* Resident Evil 2: present the few rows the subtitle needs.
+	 *
+	 * Measured on buffers read back from the GPU during the intro, in the
+	 * 264x136 mode: srcHeight comes out at 136, the visible height, while the
+	 * second line of dialogue runs to N64 row 137.8 -- so the presentation cuts
+	 * through the glyphs even though the buffer holds them whole. Stale texture
+	 * content starts at 140.3, which caps how far this may go.
+	 *
+	 * Four rows therefore, matched to the fill in RDRAMtoColorBuffer so the two
+	 * limits agree. dstY1 is left alone: four rows on 136 is under 3%, far below
+	 * anything visible, and growing it would push past the frame.
+	 *
+	 * With no French dub the subtitles carry the story, which is why this is
+	 * worth a game-specific hack at all. */
+	if ((config.generalEmulation.hacks & hack_RE2) != 0) {
+		const s32 room = (s32)pBuffer->m_pTexture->realHeight;
+		if ((srcY0 + srcHeight + 4) * (s32)pBuffer->m_scale <= room)
+			srcHeight += 4;
+	}
+
 	const u32 stride = pBuffer->m_width << pBuffer->m_size >> 1;
 	FrameBuffer *pNextBuffer = findBuffer(rdpRes.vi_origin + stride * min(u32(srcHeight) - 1, pBuffer->m_height - 1) - 1);
 	if (pNextBuffer == pBuffer)

--- a/mupen64plus-video-gliden64/src/FrameBuffer.cpp
+++ b/mupen64plus-video-gliden64/src/FrameBuffer.cpp
@@ -1549,7 +1549,21 @@ void FrameBufferList::renderBuffer()
 	if (m_pCurrent != nullptr) {
 		gfxContext.bindFramebuffer(bufferTarget::DRAW_FRAMEBUFFER, m_pCurrent->m_FBO);
 	}
-	if (config.frameBufferEmulation.forceDepthBufferClear != 0) {
+	/* Resident Evil 2 draws its characters with the depth test on and never
+	 * clears the depth buffer, so from the second frame on every character
+	 * fails GL_LESS against its own previous depth and only the 2D quads
+	 * reach the screen. Clear it between frames, as forceDepthBufferClear
+	 * does. The test is on the hack rather than on the config field because
+	 * the core reloads its options after ROM load and resets the
+	 * frameBufferEmulation fields, while generalEmulation.hacks survives.
+	 * Excluded whenever the depth map lives in what would be cleared: under
+	 * N64DepthCompare the N64 depth image textures back the background
+	 * occlusion, and under enableFragmentDepthWrite the map is written into
+	 * the GL depth attachment itself. */
+	if (config.frameBufferEmulation.forceDepthBufferClear != 0 ||
+	    ((config.generalEmulation.hacks & hack_RE2) != 0 &&
+	     config.frameBufferEmulation.N64DepthCompare == 0 &&
+	     config.generalEmulation.enableFragmentDepthWrite == 0)) {
 		drawer.clearDepthBuffer();
 	}
 

--- a/mupen64plus-video-gliden64/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
+++ b/mupen64plus-video-gliden64/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
@@ -1593,49 +1593,31 @@ public:
 					"}						\n"
 				;
 			} else {
-				if ((config.generalEmulation.hacks & hack_RE2) != 0) {
-					m_part =
-						"uniform lowp usampler2D uZlutImage;\n"
-						"highp float writeDepth()						        													\n"
-						"{																									\n"
-						;
-					if (_glinfo.isGLESX && _glinfo.noPerspective) {
-						m_part +=
-							"  if (uClampMode == 1 && (vZCoord > 1.0)) discard;	\n"
-							"  highp float FragDepth = clamp((vZCoord - uPolygonOffset) * uDepthScale.s + uDepthScale.t, 0.0, 1.0);	\n"
-							;
-					} else {
-						m_part +=
-							"  highp float FragDepth = clamp((gl_FragCoord.z * 2.0 - 1.0) * uDepthScale.s + uDepthScale.t, 0.0, 1.0);	\n"
-						;
-					}
-					m_part +=
-						"  highp int iZ = FragDepth > 0.999 ? 262143 : int(floor(FragDepth * 262143.0));				\n"
-						"  mediump int y0 = clamp(iZ/512, 0, 511);															\n"
-						"  mediump int x0 = iZ - 512*y0;																	\n"
-						"  highp uint iN64z = texelFetch(uZlutImage,ivec2(x0,y0), 0).r;											\n"
-						"  return clamp(float(iN64z)/65532.0, 0.0, 1.0);											\n"
-						"}																									\n"
+				/* No special case for RE2 here.
+				 *
+				 * Its branch converted the fragment depth into the N64 exponent/mantissa
+				 * form through the ZLUT, to match a depth map that was uploaded in that
+				 * form. TextureCache::_loadDepthTexture now decodes the map to linear as
+				 * it loads, so both sides are already in the same space and the conversion
+				 * is unnecessary. Dropping the branch also restores the uDepthSource /
+				 * uPrimDepth handling the game was missing. */
+				if (_glinfo.isGLESX && _glinfo.noPerspective) {
+					 m_part =
+						"highp float writeDepth()																	\n"
+						"{																							\n"
+						"  if (uClampMode == 1 && (vZCoord > 1.0)) discard;											\n"
+						"  if (uDepthSource != 0) return uPrimDepth;												\n"
+						"  return clamp((vZCoord - uPolygonOffset) * uDepthScale.s + uDepthScale.t, 0.0, 1.0);		\n"
+						"}																							\n"
 						;
 				} else {
-					if (_glinfo.isGLESX && _glinfo.noPerspective) {
-						 m_part =
-							"highp float writeDepth()																	\n"
-							"{																							\n"
-							"  if (uClampMode == 1 && (vZCoord > 1.0)) discard;											\n"
-							"  if (uDepthSource != 0) return uPrimDepth;												\n"
-							"  return clamp((vZCoord - uPolygonOffset) * uDepthScale.s + uDepthScale.t, 0.0, 1.0);		\n"
-							"}																							\n"
-							;
-					} else {
-						m_part =
-							"highp float writeDepth()						        									\n"
-							"{																							\n"
-							"  if (uDepthSource != 0) return uPrimDepth;												\n"
-							"  return clamp((gl_FragCoord.z * 2.0 - 1.0) * uDepthScale.s + uDepthScale.t, 0.0, 1.0);	\n"
-							"}																							\n"
-							;
-					}
+					m_part =
+						"highp float writeDepth()						        									\n"
+						"{																							\n"
+						"  if (uDepthSource != 0) return uPrimDepth;												\n"
+						"  return clamp((gl_FragCoord.z * 2.0 - 1.0) * uDepthScale.s + uDepthScale.t, 0.0, 1.0);	\n"
+						"}																							\n"
+						;
 				}
 			}
 		}

--- a/mupen64plus-video-gliden64/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
+++ b/mupen64plus-video-gliden64/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
@@ -141,22 +141,6 @@ private:
 	iUniform uDepthTex;
 };
 
-class UZLutTexture : public UniformGroup
-{
-public:
-	UZLutTexture(GLuint _program) {
-		LocateUniform(uZlutImage);
-	}
-
-	void update(bool _force) override
-	{
-		uZlutImage.set(int(graphics::textureIndices::ZLUTTex), _force);
-	}
-
-private:
-	iUniform uZlutImage;
-};
-
 class UTextures : public UniformGroup
 {
 public:
@@ -986,9 +970,6 @@ void CombinerProgramUniformFactory::buildUniforms(GLuint _program,
 	_uniforms.emplace_back(new UScreenScale(_program));
 
 	_uniforms.emplace_back(new UAlphaTestInfo(_program));
-
-	if ((config.generalEmulation.hacks & hack_RE2) != 0 && config.generalEmulation.enableFragmentDepthWrite != 0)
-		_uniforms.emplace_back(new UZLutTexture(_program));
 
 	if (config.frameBufferEmulation.N64DepthCompare != 0)
 		_uniforms.emplace_back(new UDepthInfo(_program));

--- a/mupen64plus-video-gliden64/src/Textures.cpp
+++ b/mupen64plus-video-gliden64/src/Textures.cpp
@@ -1020,10 +1020,30 @@ void TextureCache::_loadDepthTexture(CachedTexture * _pTexture, u16* _pDest)
 	if (!config.generalEmulation.enableFragmentDepthWrite)
 		return;
 
+	/* Decode the N64 depth words to linear before uploading them.
+	 *
+	 * The words are in the hardware exponent/mantissa form: bits 15..13 are the
+	 * exponent, bits 12..2 the mantissa. Uploading them raw, divided by 65535,
+	 * left the map in that non-linear space while the shader writes a linear
+	 * gl_FragDepth for everything else, so the two only agreed at the extremes:
+	 * geometry was correctly hidden behind near objects and wrongly hidden
+	 * behind distant scenery in the same frame.
+	 *
+	 * Decoding here rather than converting the fragment depth through the ZLUT
+	 * costs one pass per map instead of one lookup per fragment, and removes an
+	 * integer texture fetch from the fragment path entirely. */
+	static const struct { u32 shift; u32 add; } zFormat[8] = {
+		{ 6, 0x00000 }, { 5, 0x20000 }, { 4, 0x30000 }, { 3, 0x38000 },
+		{ 2, 0x3c000 }, { 1, 0x3e000 }, { 0, 0x3f000 }, { 0, 0x3f800 }
+	};
 	u32 size = _pTexture->realWidth * _pTexture->realHeight;
 	std::vector<f32> pDestFloat(size);
-	for (u32 i = 0; i < size; ++i)
-		pDestFloat[i] = _pDest[i] / 65535.0f;
+	for (u32 i = 0; i < size; ++i) {
+		const u16 w = _pDest[i];
+		const u32 e = (w >> 13) & 7;
+		const u32 m = (w >> 2) & 0x7ff;
+		pDestFloat[i] = f32((m << zFormat[e].shift) + zFormat[e].add) / 262143.0f;
+	}
 
 	Context::InitTextureParams params;
 	params.handle = _pTexture->name;

--- a/mupen64plus-video-gliden64/src/mupenplus/GLideN64.custom.ini.h
+++ b/mupen64plus-video-gliden64/src/mupenplus/GLideN64.custom.ini.h
@@ -278,6 +278,7 @@ char customini[] =
 "frameBufferEmulation\\copyFromRDRAM=1\n"
 "frameBufferEmulation\\copyToRDRAM=0\n"
 "frameBufferEmulation\\copyDepthToRDRAM=0\n"
+"generalEmulation\\enableFragmentDepthWrite=1\n"
 "\n"
 "[ROCKMAN%20DASH]\n"
 "Good_Name=Rockman Dash - Hagane no Boukenshin (J)\n"


### PR DESCRIPTION
Resident Evil 2 was unplayable under GLideN64: characters vanished from rooms,
the 3D actors ignored the pre-rendered backgrounds' occlusion, subtitles lost
their second line, and bands of noise framed the picture. Five independent
defects, one commit each (oldest first):

1. **Decode the N64 depth map to linear when loading it.** `_loadDepthTexture`
   uploaded the depth image words raw (hardware exponent/mantissa form) while
   the shader writes a linear `gl_FragDepth` for everything else — the two only
   agreed at the extremes, so geometry was correctly hidden behind near objects
   and wrongly hidden behind distant scenery within the same frame. Decoding on
   load costs one pass per map instead of a ZLUT lookup per fragment, and lets
   the RE2 branch of `writeDepth()` (and the now-unreferenced ZLUT combiner
   uniform group) go.

2. **Bound the RDRAM colour upload.** Two overreaches, both measured by reading
   the textures back from the GPU: the copy ran into buffers the RDP owns
   (the start-address guard is bypassed in interlaced cutscenes, where the VI
   origin sits a line inside the page), and when the address does not match the
   buffer start the height came from `VI_GetMaxBufferHeight` — a global
   ceiling, unrelated to the buffer, painting noise over hundreds of rows the
   game never wrote. The upload is now bounded to the buffer's own height and
   to what the VI shows.

3. **Keep the second subtitle line.** In the 264x136 cutscene mode the buffer
   is filled and presented to exactly `VI.real_height` rows while the dialogue
   runs to N64 row 137.8, cutting through the glyphs — and the game ships with
   no dub, so the subtitles carry the story. A four-row margin (taken from the
   captures, not chosen) is added to the fill and the presented height,
   only when the texture has the room.

4. **Pin `EnableFragmentDepthWrite` in the per-game ini.** The game needs it to
   sort actors against the pre-rendered backgrounds. The declared default is
   already True, so nothing changes out of the box; this only stops a user who
   turns the global option off (it costs frames on tile-based GPUs) from
   silently breaking this game.

5. **Clear the depth buffer between frames.** The game draws its characters
   with the depth test on and never clears depth — zero clears over 720 probed
   frames — so from the second frame on, every character failed the test
   against its own previous depth and was rejected whole: rooms without
   characters. The clear is bounded to where it is safe: not under
   `N64DepthCompare` (the depth image holds the room's occlusion map) and not
   under `EnableFragmentDepthWrite` (the same map lives in the GL depth
   attachment this clear would wipe).

Tested on aarch64 (Raspberry Pi 5, GLES 3.1): intro, room transitions and
in-room play are correct — actors occluded by scenery, both subtitle lines,
no noise bands. The depth-path changes were also checked for regressions on
other N64DepthCompare / fragment-depth-write games (Perfect Dark, South Park
Rally, Space Station Silicon Valley, Body Harvest).