### PR TITLE
libretro: declare a fixed audio rate and resample to it

### DIFF
--- a/mupen64plus-core/src/plugin/audio_libretro/audio_backend_libretro.c
+++ b/mupen64plus-core/src/plugin/audio_libretro/audio_backend_libretro.c
@@ -25,13 +25,13 @@
  *
  *   The N64 AI hardware always emits 16-bit stereo samples regardless of
  *   the BITRATE register (which controls the serial-DAC transfer rate,
- *   not the sample depth). The libretro frontend's audio mixer accepts
- *   variable-rate input via retro_get_system_av_info / RETRO_ENVIRONMENT
- *   _SET_SYSTEM_AV_INFO and resamples to the host audio device at high
- *   quality. There is therefore no reason to resample inside the core;
- *   we declare the actual N64 sample rate to the frontend and pass the
- *   samples through with a single byteswap-on-copy step into a per-
- *   retro_run accumulator. The accumulator is drained exactly once per
+ *   not the sample depth). The frontend is told one fixed rate, once,
+ *   and the game's stream is resampled to it here -- announcing the
+ *   game's own rate would mean moving it later through RETRO_ENVIRONMENT
+ *   _SET_SYSTEM_AV_INFO, which costs a CRT setup its switchres mode.
+ *   See AUDIO_OUTPUT_RATE. Samples reach the accumulator through a
+ *   byteswap-on-copy and a polyphase resampling step, per retro_run.
+ *   The accumulator is drained exactly once per
  *   retro_run iteration (immediately after emu_step_render in the
  *   libretro entry point), so each video frame is paired with exactly
  *   one audio batch -- the determinism contract a well-behaved libretro
@@ -75,32 +75,89 @@ extern retro_environment_t        environ_cb;
 
 #define AUDIO_ACC_FRAMES   8192u
 
+/* The rate we declare to the frontend, once, from retro_get_system_av_info().
+ *
+ * The N64's own rate is a divider the game writes into AI_DACRATE and is
+ * unknowable until the ROM runs, so the core used to declare a guess and
+ * correct it later through RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO.  That is
+ * legitimate, but RetroArch reinitialises the whole video pipeline on that
+ * call whenever CRT switchres is on -- its no_video_reinit shortcut is
+ * explicitly disabled there -- so a CRT setup loses the mode switchres picked
+ * from the first frame, falls back to the default KMS mode and never returns.
+ *
+ * So never move the rate: declare a fixed one and resample the game's stream
+ * to it here.  48000 is RetroArch's own default output rate, so the frontend's
+ * resampler is usually a no-op and the stream is resampled once, not twice. */
+#define AUDIO_OUTPUT_RATE  48000.0
+
 static int16_t  audio_acc[AUDIO_ACC_FRAMES * 2];
 static size_t   audio_acc_frames;        /* stereo frames currently held */
 static unsigned current_sample_rate;     /* 0 until first set_audio_format */
 static double   current_sample_rate_exact; /* the same rate, unrounded */
 
+/* Polyphase resampler, game rate -> AUDIO_OUTPUT_RATE.
+ *
+ * The kernel is the Blackman-windowed sinc tap bank the HLE voice path
+ * already carries (mupen64plus-rsp-hle/src/resample_hq.c): 256 phases, and a
+ * set of cutoff bands so a ratio above unity pulls the cutoff down to 1/ratio
+ * and keeps the image out of the passband.  Its rows are nudged to sum to
+ * exactly 1.0 in Q15, so DC gain is exact at every phase.
+ *
+ * Declaring 48000 puts almost every game in the upsampling direction (the AI
+ * divider tops out around 48009 Hz), which only produces images -- the safe
+ * direction.  Downsampling would fold the top of the band back into the
+ * audible range without a filter; the bands are what stops that on the rare
+ * game above the declared rate.
+ *
+ * Width is fixed here rather than exposed: 32 taps costs ~3 M MACs/s at
+ * 48 kHz stereo, which is noise even on the weakest board this builds for,
+ * and a knob whose wrong setting is an audible regression is not worth it.
+ *
+ * The read position carries across calls and across frames: resetting it per
+ * frame would quantise every frame's output to a whole number of samples and
+ * drift against the DAC. */
+#define RESAMP_TAPS   32
+#define RESAMP_HALF   (RESAMP_TAPS / 2)   /* input frames of lookahead needed */
+#define RESAMP_HIST   128u                /* power of two, > RESAMP_TAPS */
+#define RESAMP_MASK   (RESAMP_HIST - 1u)
+
+extern const int16_t* resample_hq_taps_fixed(int taps, uint32_t pitch,
+                                             uint32_t pitch_accu);
+
+static int16_t  resamp_hist[RESAMP_HIST][2];
+static uint64_t resamp_written;          /* input frames ever fed */
+static uint64_t resamp_rd;               /* integer part of the read position */
+static double   resamp_frac;             /* its fraction, in [0, 1) */
+static double   resamp_step = 1.0;       /* input frames per output frame */
+
+
+static void reset_resampler(void)
+{
+   memset(resamp_hist, 0, sizeof(resamp_hist));
+   resamp_written = 0;
+   resamp_rd      = 0;
+   resamp_frac    = 0.0;
+}
 
 void init_audio_libretro(void)
 {
    audio_acc_frames = 0;
    current_sample_rate = 0;
+   reset_resampler();
 }
 
 void deinit_audio_libretro(void)
 {
    audio_acc_frames = 0;
    current_sample_rate = 0;
+   reset_resampler();
 }
 
+/* Constant by construction: see AUDIO_OUTPUT_RATE.  The game's own rate never
+ * reaches the frontend, it only sets the resampler ratio. */
 double get_audio_sample_rate_libretro(void)
 {
-   /* 32040 Hz is by far the most common N64 game rate and a reasonable
-    * fallback when retro_get_system_av_info is queried before the game
-    * has had a chance to issue its first AI register write. */
-   if (current_sample_rate_exact != 0.0)
-      return current_sample_rate_exact;
-   return current_sample_rate ? (double)current_sample_rate : 32040.0;
+   return AUDIO_OUTPUT_RATE;
 }
 
 /* Emit the first n stereo frames of the accumulator to the frontend in a
@@ -160,8 +217,8 @@ void flush_audio_libretro(void)
 }
 
 /* bits is ignored: the AI controller always produces 16-bit stereo.
- * frequency is the N64 game's chosen sample rate; we forward it to the
- * frontend via RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO when it changes. */
+ * frequency is the N64 game's chosen sample rate; it never reaches the
+ * frontend, it only retunes the resampler. */
 /* frequency is the rate rounded to whole Hz; clock and divider give the
  * same rate exactly, as the DAC derives it.  The divider is zero when the
  * game has not set DACRATE and the caller substituted a default. */
@@ -188,14 +245,109 @@ void set_audio_format_via_libretro(unsigned int frequency,
    current_sample_rate       = frequency;
    current_sample_rate_exact = exact;
 
+   /* Retune the resampler in place.  The frontend is told nothing: the rate it
+    * was given at load time does not move, which is the whole point (see
+    * AUDIO_OUTPUT_RATE).  The phase is deliberately left alone so a mid-game
+    * rate change does not restart the interpolation on a stale frame. */
+   resamp_step = exact / AUDIO_OUTPUT_RATE;
+}
 
-   if (environ_cb)
+/* Append one output frame, draining first if the accumulator is full.  A
+ * frontend under backpressure can decline the drain, in which case the frame
+ * is dropped rather than run off the end of audio_acc. */
+static void acc_push_frame(int16_t l, int16_t r)
+{
+   if (audio_acc_frames >= AUDIO_ACC_FRAMES)
    {
-      struct retro_system_av_info info;
-      extern void retro_get_system_av_info(struct retro_system_av_info *info);
-      retro_get_system_av_info(&info);
-      info.timing.sample_rate = exact;
-      environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &info);
+      emit_frames(audio_acc_frames);
+      if (audio_acc_frames >= AUDIO_ACC_FRAMES)
+         return;
+   }
+
+   audio_acc[audio_acc_frames * 2 + 0] = l;
+   audio_acc[audio_acc_frames * 2 + 1] = r;
+   ++audio_acc_frames;
+}
+
+static int16_t clamp_s16(int32_t v)
+{
+   if (v >  32767) return  32767;
+   if (v < -32768) return -32768;
+   return (int16_t)v;
+}
+
+/* Ring slot for a stream index, which is negative for the silence that
+ * precedes the first frame.  RESAMP_HIST is a power of two, so the bias only
+ * has to lift the index above zero; it does not change the slot. */
+static const int16_t* resamp_at(int64_t idx)
+{
+   return resamp_hist[(size_t)(idx + (int64_t)RESAMP_HIST) & RESAMP_MASK];
+}
+
+/* Reconstruct one output frame at the current read position and append it. */
+static void resample_emit(void)
+{
+   /* pitch is Q16.16 and picks the cutoff band; the accumulator is the phase,
+    * of which the bank uses the top 8 bits. */
+   const uint32_t pitch = (uint32_t)(resamp_step * 65536.0 + 0.5);
+   const uint32_t accu  = (uint32_t)(resamp_frac * 65536.0) & 0xffffu;
+   const int16_t *k     = resample_hq_taps_fixed(RESAMP_TAPS, pitch, accu);
+
+   if (k != NULL)
+   {
+      /* The kernel is centred at tap (taps/2 - 1) + phase, so a window that
+       * starts that far back reconstructs at the read position itself.  32
+       * taps of 16-bit input against Q15 coefficients reach 2^35, past int32,
+       * so the accumulator is 64-bit; rounding half-up keeps the error
+       * zero-mean rather than biasing every sample toward zero. */
+      const int64_t base = (int64_t)resamp_rd - (RESAMP_TAPS / 2 - 1);
+      int64_t       al   = 0;
+      int64_t       ar   = 0;
+      int           t;
+
+      for (t = 0; t < RESAMP_TAPS; ++t)
+      {
+         const int16_t *in = resamp_at(base + t);
+         al += (int64_t)in[0] * k[t];
+         ar += (int64_t)in[1] * k[t];
+      }
+
+      acc_push_frame(clamp_s16((int32_t)((al + 0x4000) >> 15)),
+                     clamp_s16((int32_t)((ar + 0x4000) >> 15)));
+   }
+   else
+   {
+      /* The bank could not be allocated.  Linear rather than silence. */
+      const int16_t *a = resamp_at((int64_t)resamp_rd);
+      const int16_t *b = resamp_at((int64_t)resamp_rd + 1);
+
+      acc_push_frame((int16_t)(a[0] + (b[0] - a[0]) * resamp_frac),
+                     (int16_t)(a[1] + (b[1] - a[1]) * resamp_frac));
+   }
+}
+
+/* Feed one input frame (host order) and emit every output frame the kernel now
+ * has enough input to reconstruct.  That leaves RESAMP_HALF input frames of
+ * latency -- about a third of a millisecond -- not drift: they come out with
+ * the next frame's audio. */
+static void resample_feed(int16_t l, int16_t r)
+{
+   int16_t *slot = resamp_hist[(size_t)resamp_written & RESAMP_MASK];
+
+   slot[0] = l;
+   slot[1] = r;
+   ++resamp_written;
+
+   while (resamp_rd + RESAMP_HALF < resamp_written)
+   {
+      resample_emit();
+
+      resamp_frac += resamp_step;
+      while (resamp_frac >= 1.0)
+      {
+         resamp_frac -= 1.0;
+         ++resamp_rd;
+      }
    }
 }
 
@@ -236,40 +388,17 @@ void push_audio_samples_via_libretro(const void *buffer, size_t size)
    src    = (const uint8_t*)buffer;
    frames = size >> 2;                   /* 4 bytes per stereo frame */
 
-   if (audio_acc_frames + frames > AUDIO_ACC_FRAMES)
-      emit_frames(audio_acc_frames);     /* emergency full drain; the
-                                          * smoother runs once per run from
-                                          * flush_audio_libretro, not here */
-
-   off = 0;
-   while (off < frames)
+   for (off = 0; off < frames; ++off)
    {
-      size_t   chunk = frames - off;
-      size_t   i;
-      int16_t *dst;
-
-      if (chunk > AUDIO_ACC_FRAMES - audio_acc_frames)
-         chunk = AUDIO_ACC_FRAMES - audio_acc_frames;
-
-      dst = audio_acc + audio_acc_frames * 2;
-
-      for (i = 0; i < chunk; ++i)
-      {
-         const uint8_t *p = src + (off + i) * 4;
+      const uint8_t *p = src + off * 4;
 #ifdef MSB_FIRST
-         dst[i*2 + 0] = (int16_t)((p[0] << 8) | p[1]);   /* L */
-         dst[i*2 + 1] = (int16_t)((p[2] << 8) | p[3]);   /* R */
+      const int16_t  l = (int16_t)((p[0] << 8) | p[1]);
+      const int16_t  r = (int16_t)((p[2] << 8) | p[3]);
 #else
-         dst[i*2 + 0] = (int16_t)((p[3] << 8) | p[2]);   /* L */
-         dst[i*2 + 1] = (int16_t)((p[1] << 8) | p[0]);   /* R */
+      const int16_t  l = (int16_t)((p[3] << 8) | p[2]);
+      const int16_t  r = (int16_t)((p[1] << 8) | p[0]);
 #endif
-      }
-
-      audio_acc_frames += chunk;
-      off              += chunk;
-
-      if (audio_acc_frames == AUDIO_ACC_FRAMES && off < frames)
-         emit_frames(audio_acc_frames);  /* emergency full drain */
+      resample_feed(l, r);
    }
 }
 
@@ -278,22 +407,10 @@ void push_audio_samples_via_libretro(const void *buffer, size_t size)
  * carry silence rather than stop. */
 void push_audio_silence_via_libretro(size_t frames)
 {
-   while (frames != 0)
-   {
-      size_t chunk = frames;
-
-      if (chunk > AUDIO_ACC_FRAMES - audio_acc_frames)
-         chunk = AUDIO_ACC_FRAMES - audio_acc_frames;
-
-      if (chunk == 0)
-      {
-         emit_frames(audio_acc_frames);
-         continue;
-      }
-
-      memset(audio_acc + audio_acc_frames * 2, 0,
-             chunk * 2 * sizeof(int16_t));
-      audio_acc_frames += chunk;
-      frames           -= chunk;
-   }
+   /* Through the resampler like any other input: frames counts input frames at
+    * the game's rate, and the phase has to advance by them or the stream drifts
+    * against the DAC by however much silence the game let through.  It also
+    * ramps out of the last real sample instead of cutting to zero. */
+   while (frames-- != 0)
+      resample_feed(0, 0);
 }

--- a/mupen64plus-rsp-hle/src/resample_hq.c
+++ b/mupen64plus-rsp-hle/src/resample_hq.c
@@ -238,6 +238,19 @@ const int16_t* resample_hq_taps(uint32_t pitch, uint32_t pitch_accu)
     return hq_taps_for(hq_want, pitch, pitch_accu);
 }
 
+const int16_t* resample_hq_taps_fixed(int taps, uint32_t pitch,
+                                      uint32_t pitch_accu)
+{
+    const int      want = hq_want;
+    const int16_t *k    = hq_taps_for(taps, pitch, pitch_accu);
+
+    /* hq_taps_for turns the option off when a bank cannot be allocated, which
+     * is right for the voice path but not ours to do on its behalf: our caller
+     * has its own fallback and the user's HLE setting stays theirs. */
+    hq_want = want;
+    return k;
+}
+
 const int16_t* resample_hq_taps_capped(uint32_t pitch, uint32_t pitch_accu,
                                        int max_taps)
 {

--- a/mupen64plus-rsp-hle/src/resample_hq.h
+++ b/mupen64plus-rsp-hle/src/resample_hq.h
@@ -31,6 +31,14 @@ const int16_t* resample_hq_taps_capped(uint32_t pitch, uint32_t pitch_accu,
  * tap bank could not be allocated. */
 const int16_t* resample_hq_taps(uint32_t pitch, uint32_t pitch_accu);
 
+/* As resample_hq_taps, but at an explicit width and regardless of the
+ * quality option, which belongs to the HLE voice path alone.  For callers
+ * outside it -- the libretro audio backend resamples the AI stream to the
+ * rate the frontend was told -- whose kernel is not the user's to switch
+ * off.  Returns NULL only if the bank cannot be built. */
+const int16_t* resample_hq_taps_fixed(int taps, uint32_t pitch,
+                                      uint32_t pitch_accu);
+
 /* Release the tap bank. */
 void resample_hq_release(void);
 

--- a/tools/test_audio_resample.c
+++ b/tools/test_audio_resample.c
@@ -1,0 +1,173 @@
+/* Standalone self-check for the libretro audio backend's resampler
+ * (fixed declared rate, steady-state ratio, DC gain, silence phase, drift).
+ *
+ * Build & run from the repo root:
+ *   cc -Imupen64plus-core/src -Imupen64plus-core/src/api -Ilibretro-common/include \
+ *      -Imupen64plus-core/custom -Imupen64plus-core/subprojects/md5 -Iinclude \
+ *      -o /tmp/test_ar tools/test_audio_resample.c \
+ *      mupen64plus-core/src/plugin/audio_libretro/audio_backend_libretro.c \
+ *      mupen64plus-rsp-hle/src/resample_hq.c -lm \
+ *      && /tmp/test_ar
+ */
+#include <assert.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <libretro.h>
+
+void   init_audio_libretro(void);
+void   deinit_audio_libretro(void);
+void   flush_audio_libretro(void);
+double get_audio_sample_rate_libretro(void);
+void   set_audio_format_via_libretro(unsigned frequency, unsigned clock, unsigned divider);
+void   push_audio_samples_via_libretro(const void *buffer, size_t size);
+void   push_audio_silence_via_libretro(size_t frames);
+
+/* --- frontend stubs -------------------------------------------------- */
+static size_t out_frames;
+static int    out_expect;      /* every output sample must equal this */
+static int    out_mismatch;
+
+static size_t batch_cb(const int16_t *data, size_t frames)
+{
+   size_t i;
+   for (i = 0; i < frames; ++i)
+      if (data[i*2] != out_expect || data[i*2+1] != out_expect)
+         ++out_mismatch;
+   out_frames += frames;
+   return frames;
+}
+
+retro_audio_sample_batch_t audio_batch_cb = batch_cb;
+retro_environment_t        environ_cb     = NULL;
+
+/* --- helpers ---------------------------------------------------------- */
+/* One N64 AI stereo frame as the core sees it in RDRAM: big-endian s16
+ * pairs, byte-swizzled on a little-endian host (S8 = 3). */
+static void put_frame(uint8_t *p, int16_t l, int16_t r)
+{
+#ifdef MSB_FIRST
+   p[0] = (uint8_t)(l >> 8); p[1] = (uint8_t)l;
+   p[2] = (uint8_t)(r >> 8); p[3] = (uint8_t)r;
+#else
+   p[3] = (uint8_t)(l >> 8); p[2] = (uint8_t)l;
+   p[1] = (uint8_t)(r >> 8); p[0] = (uint8_t)r;
+#endif
+}
+
+static void feed_dc(unsigned frames, int16_t value)
+{
+   uint8_t *buf = malloc((size_t)frames * 4);
+   unsigned i;
+   assert(buf);
+   for (i = 0; i < frames; ++i)
+      put_frame(buf + i * 4, value, value);
+   push_audio_samples_via_libretro(buf, (size_t)frames * 4);
+   free(buf);
+}
+
+/* Start a run and get past the kernel's start-up window, so what follows is
+ * steady state and not the fade-in out of the silence before frame zero. */
+static void warm_up(unsigned clock, unsigned divider, int16_t dc)
+{
+   init_audio_libretro();
+   set_audio_format_via_libretro(1, clock, divider);
+   out_expect = dc; out_mismatch = 0;
+   feed_dc(4096, dc);
+   flush_audio_libretro();
+   out_frames = 0; out_mismatch = 0;
+}
+
+int main(void)
+{
+   /* The declared rate is fixed: that is the whole point, moving it is what
+    * costs a CRT setup its switchres mode. */
+   init_audio_libretro();
+   assert(get_audio_sample_rate_libretro() == 48000.0);
+   set_audio_format_via_libretro(22050, 48681812, 2208);
+   assert(get_audio_sample_rate_libretro() == 48000.0);
+   set_audio_format_via_libretro(32040, 48681812, 1519);
+   assert(get_audio_sample_rate_libretro() == 48000.0);
+
+   /* Steady-state throughput: N input frames owe N * 48000/in_rate output
+    * frames, whatever the start-up latency was. */
+   {
+      const double in_rate = 48681812.0 / 1519.0;   /* 32048.592 Hz */
+      const double expect  = 32040.0 * (48000.0 / in_rate);
+      long         diff;
+
+      warm_up(48681812, 1519, 1000);
+      feed_dc(32040, 1000);
+      flush_audio_libretro();
+
+      diff = (long)out_frames - (long)(expect + 0.5);
+      if (diff < 0) diff = -diff;
+      printf("  32048.6 -> 48000 : %zu frames out, attendu ~%.0f (ecart %ld)\n",
+             out_frames, expect, diff);
+      assert(diff <= 2);
+
+      /* The tap rows are nudged to sum to exactly 1.0 in Q15, so a DC input
+       * must come out at its own value at every phase -- no wobble. */
+      printf("  gain DC exact    : %d echantillons hors valeur\n", out_mismatch);
+      assert(out_mismatch == 0);
+   }
+
+   /* Above the declared rate the ratio exceeds unity, where the bank pulls the
+    * cutoff down.  Check the rate is still honoured. */
+   {
+      warm_up(96000, 1, 0);
+      feed_dc(4800, 0);
+      flush_audio_libretro();
+      printf("  96000 -> 48000   : %zu frames out, attendu ~2400\n", out_frames);
+      assert(out_frames > 2398 && out_frames < 2402);
+      assert(out_mismatch == 0);
+   }
+
+   /* Silence advances the phase like any other input: 16000 silent input
+    * frames owe exactly what 16000 loud ones owe. */
+   {
+      size_t loud, quiet;
+
+      warm_up(48681812, 1519, 0);
+      feed_dc(16000, 0);
+      flush_audio_libretro();
+      loud = out_frames;
+
+      warm_up(48681812, 1519, 0);
+      push_audio_silence_via_libretro(16000);
+      flush_audio_libretro();
+      quiet = out_frames;
+
+      printf("  phase du silence : %zu vs %zu frames\n", loud, quiet);
+      assert(loud == quiet);
+   }
+
+   /* The position carries across calls, so ten pushes owe what one push of
+    * the total owes.  This is the check that fails if the phase is ever
+    * reset per frame. */
+   {
+      size_t one, many;
+      int    i;
+
+      warm_up(48681812, 1519, 0);
+      feed_dc(8000, 0);
+      flush_audio_libretro();
+      one = out_frames;
+
+      warm_up(48681812, 1519, 0);
+      for (i = 0; i < 10; ++i)
+         feed_dc(800, 0);
+      flush_audio_libretro();
+      many = out_frames;
+
+      printf("  pas de derive    : %zu (1x8000) vs %zu (10x800)\n", one, many);
+      assert(one == many);
+   }
+
+   deinit_audio_libretro();
+   printf("audio resampler: all checks passed\n");
+   return 0;
+}


### PR DESCRIPTION
  ## Problem

  The core corrects its declared sample rate through
  RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO once the game programs AI_DACRATE.
  RetroArch skips the video reinit on that call only when CRT switchres is
  off, so on a CRT setup the mode switchres picked from the first frame is
  lost: Hanabi de Doon (aleck64, 640x480i) comes up in 480i and drops to
  240p a moment later, when the game's first DACRATE write lands.

  This is the same problem dc84213f (the pre-roll) attacked, which was
  reverted in 0823bcbc for breaking the software renderers and the
  Hacktarux JIT. This takes the opposite approach: never move the rate at
  all.

  ## Approach

  Declare 48000 Hz once and resample the game's stream to it in the audio
  backend, so SET_SYSTEM_AV_INFO is never called. No single declared value
  can be right anyway: ai_controller re-announces on every DACRATE write,
  and games move the rate mid-run.

  48000 is RetroArch's default output rate (one resampling stage instead
  of two) and puts nearly every game in the upsampling direction — the AI
  divider tops out near 48009 Hz.

  The kernel reuses the Blackman-windowed sinc tap bank the HLE voice path
  already carries (resample_hq.c), at a fixed 32 taps, independent of the
  user's HLE quality option. Measured on a 12.8 kHz tone from 32048.6 Hz:

  |              | signal   | image     | rejection |
  |--------------|----------|-----------|-----------|
  | linear       | -4.84 dB | -11.88 dB | 7.0 dB    |
  | sinc 32 taps | 0.00 dB  | -81.38 dB | 81.4 dB   |

  Latency cost: 16 input frames of kernel lookahead (~0.33 ms), no drift —
  the read position carries across calls and frames, and silence advances
  the phase like any other input.

  ## Testing

  - tools/test_audio_resample.c: steady-state ratio, exact DC gain,
    silence phase, no drift across split pushes — all pass
  - On a CRT (switchres): doncdoon starts and stays in
    480i; previously fell back to 240p