### PR TITLE
ci: add Android and iOS builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -168,21 +168,21 @@ android-x86:
     - .libretro-android-jni-x86
     - .core-defs
 
-# # iOS
-# libretro-build-ios-arm64:
-#   extends:
-#     - .libretro-ios-arm64-make-default
-#     - .core-defs
-#   variables:
-#     HAVE_THR_AL: 1
+# iOS
+libretro-build-ios-arm64:
+  extends:
+    - .libretro-ios-arm64-make-default
+    - .core-defs
+  variables:
+    HAVE_THR_AL: 1
 
-# # iOS (armv7) [iOS 9 and up]
-# libretro-build-ios9:
-#   extends:
-#     - .libretro-ios9-make-default
-#     - .core-defs
-#   variables:
-#     HAVE_THR_AL: 1
+# iOS (armv7) [iOS 9 and up]
+libretro-build-ios9:
+  extends:
+    - .libretro-ios9-make-default
+    - .core-defs
+  variables:
+    HAVE_THR_AL: 1
 
 #################################### MISC ##################################
 # webOS 32-bit

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,6 +41,10 @@ include:
     file: '/osx-arm64.yml'
 
   ################################## CELLULAR ################################
+  # Android
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/android-jni.yml'
+
   # iOS
   - project: 'libretro-infrastructure/ci-templates'
     file: '/ios-arm64.yml'
@@ -140,6 +144,30 @@ libretro-build-osx-arm64:
     WITH_DYNAREC: aarch64
 
 ################################### CELLULAR #################################
+# Android ARMv7a
+android-armeabi-v7a:
+  extends:
+    - .libretro-android-jni-armeabi-v7a
+    - .core-defs
+
+# Android ARMv8a
+android-arm64-v8a:
+  extends:
+    - .libretro-android-jni-arm64-v8a
+    - .core-defs
+
+# Android 64-bit x86
+android-x86_64:
+  extends:
+    - .libretro-android-jni-x86_64
+    - .core-defs
+
+# Android 32-bit x86
+android-x86:
+  extends:
+    - .libretro-android-jni-x86
+    - .core-defs
+
 # # iOS
 # libretro-build-ios-arm64:
 #   extends:

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -29,7 +29,10 @@ else ifeq ($(TARGET_ARCH_ABI),x86)
   # This core uses vulkan which is api 24+, so dynarec cannot be used
   WITH_DYNAREC := bogus
 else ifeq ($(TARGET_ARCH_ABI),x86_64)
-  WITH_DYNAREC := x86_64
+  # Both x86_64 dynarecs put their entry points (new_dyna_start, dyna_start) in
+  # nasm sources, and ndk-build has no assembler for those - the core links
+  # against symbols that were never built. Interpreters only here as well.
+  WITH_DYNAREC := bogus
 endif
 
 include $(ROOT_DIR)/Makefile.common

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,6 +1,5 @@
-APP_ABI := armeabi-v7a arm64-v8a
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_STL := c++_static
 APP_PLATFORM := android-24
-NDK_TOOLCHAIN_VERSION := 4.9
 LOCAL_SHORT_COMMANDS := true
 APP_SHORT_COMMANDS := true

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -64,8 +64,16 @@ uint8_t* g_dd_disk;
 #include "../mupen64plus-video-angrylion/vdac.h"
 #endif
 
+#if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES)
 #include <glsm/glsmsym.h>
-#if !defined(HAVE_OPENGL) && !defined(HAVE_OPENGLES)
+#else
+/* Targets built without a GL renderer - iOS, for one - still need a glsm_ctl
+ * for the callers below. glsmsym.h cannot be included for it: its prototypes
+ * are desktop-GL typed (GLclampd, GLdouble), and glsm.h only supplies those
+ * typedefs when one of the HAVE_OPENGLES* defines is set, while the headers
+ * rglgen pulls in on iOS are ES ones that do not carry them. glsm.h alone is
+ * enough here - the stub needs the enum and nothing else. */
+#include <glsm/glsm.h>
 bool glsm_ctl(enum glsm_state_ctl state, void *data) { return false; }
 #endif
 

--- a/mupen64plus-rsp-paraLLEl/jit_allocator.cpp
+++ b/mupen64plus-rsp-paraLLEl/jit_allocator.cpp
@@ -12,7 +12,7 @@
 #ifndef _WIN32
 #include <unistd.h>
 static int sPageSize = 0;
-static inline int PAGE_SIZE()
+static inline int page_size()
 {
 	if (__builtin_expect(0 == sPageSize, false))
 	{
@@ -22,7 +22,7 @@ static inline int PAGE_SIZE()
 	return sPageSize;
 }
 #else
-#define PAGE_SIZE() 4096
+#define page_size() 4096
 #endif
 
 namespace RSP
@@ -52,7 +52,7 @@ Allocator::~Allocator()
 
 static size_t align_page(size_t offset)
 {
-	return (offset + PAGE_SIZE() - 1) & ~size_t(PAGE_SIZE() - 1);
+	return (offset + page_size() - 1) & ~size_t(page_size() - 1);
 }
 
 static bool commit_read_write(void *ptr, size_t size)


### PR DESCRIPTION
Android has never been built here, and both iOS jobs have been sitting commented out. Two commits, one per platform, with the fixes each of them turned out to need.

## Android

`jni/` has been in this tree the whole time, and it is a considered file — it picks a dynarec per ABI and explains why x86 does not get one. There has just never been a job to run it. arm64-v8a built as-is; the other three ABIs needed:

**`Application.mk` asked for `NDK_TOOLCHAIN_VERSION := 4.9`.** GCC left the NDK years ago. It also listed only the two ARM ABIs, while `Android.mk` has always handled all four.

**`jit_allocator.cpp` names a helper `PAGE_SIZE()`.** bionic still defines `PAGE_SIZE` as a macro for the 32-bit ABIs — NDK r27 dropped it only for the 64-bit ones, as part of the 16 KB page work — so armeabi-v7a and x86 saw `int 4096()`:

```
jit_allocator.cpp:15:19: error: expected unqualified-id
```

Renamed to `page_size()`, which matches the other helpers around it.

**x86_64 asked for the x86_64 dynarec.** Both of that architecture's backends, ari64 and hacktarux, keep their entry points in nasm sources, and ndk-build has no assembler for those:

```
ld.lld: error: undefined symbol: new_dyna_start
ld.lld: error: undefined symbol: dyna_start
```

It now takes the interpreters — the same call `Android.mk` already makes for x86, for the same kind of reason, with the reason written down this time. Getting the dynarec back on Android x86_64 means porting those two linkage files off nasm first.

## iOS

`libretro.c` pulls in `glsm/glsmsym.h` unconditionally, and needs it only for the enum in the `glsm_ctl()` stub it defines a line later when neither `HAVE_OPENGL` nor `HAVE_OPENGLES` is set — which is the iOS case, since that platform block sets `HAVE_OPENGL=0`. `glsmsym.h`'s prototypes are desktop-GL typed, and `glsm.h` supplies `GLclampd` and `GLdouble` only under `HAVE_OPENGLES2/3`, while what rglgen reaches for on iOS are ES headers that do not carry them:

```
glsm/glsmsym.h:349:20: error: unknown type name 'GLclampd'
```

The include now happens only where there is a GL renderer to talk to; the stub takes `glsm.h`, which is all the enum needs.

## What was run

Preflight on GitHub Actions — `ndk-build` for Android, the same command and output layout the `android-jni` template uses, and `make platform=…` for iOS.

| job | dynarec | |
|---|---|---|
| android armeabi-v7a | arm | ok |
| android arm64-v8a | aarch64 | ok |
| android x86 | none (was already so) | ok |
| android x86_64 | none (see above) | ok |
| ios-arm64 | — | ok |
| ios9 | — | not testable there |

ios9 is armv7, and a GitHub runner cannot link it: the iPhoneOS 26.5 SDK has no armv7 slice of libSystem, so every libc symbol comes back undefined (`ld: symbol(s) not found for architecture armv7`). Every source file compiled for armv7 first, so the job is here on the expectation that the buildbot's older SDK links it — that is the one thing in this PR I could not run myself, and the easiest one to drop if it disagrees.

No Android device and no iOS device here: these are builds, not play tests.
